### PR TITLE
Fixing Makefile so docs can be built: issue #51

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,21 +8,10 @@ PACKAGE=CCSI_$(PRODUCT)_$(VERSION).zip
 
 PAYLOAD = docs/*.pdf \
           *.py \
-          *.bat \
-          *.wxs *.wxi \
-          dmf_lib \
           examples \
           foqus_lib \
-          setup \
           test \
-          turb_client \
           $(LICENSE)
-
-DMF_LIB_EXCLUDES = dmf_lib/java/src\* \
-                   dmf_lib/java/lib\* \
-                   dmf_lib/java/bin\* \
-                   dmf_lib/java/.ant\* \
-                   dmf_lib/java/*.xml
 
 # OS detection & changes
 UNAME := $(shell uname)
@@ -42,18 +31,13 @@ all: $(PACKAGE)
 
 # Make zip file without extra file attributes (-X) so md5sum doesn't
 # change if the payload hasn't
-$(PACKAGE): $(PAYLOAD) docs dmf
-	@zip -qXr $(PACKAGE) $(PAYLOAD) -x $(DMF_LIB_EXCLUDES)
+$(PACKAGE): $(PAYLOAD) docs
+	@zip -qXr $(PACKAGE) $(PAYLOAD)
 	@$(MD5BIN) $(PACKAGE)
 
 docs:
 	@$(MAKE) -C manual
 
-dmf:
-	@cd dmf_lib/java && ant
-
 clean:
 	@$(MAKE) -C manual clean
-	@cd dmf_lib/java && ant clean
-	@if [ -f turb_client/Makefile ]; then $(MAKE) -C turb_client clean; fi
 	@rm -rf $(PACKAGE) $(DOCDIR) *~


### PR DESCRIPTION
 by removing dmf (#94) and turb_client (#117) bits from Makefile