### PR TITLE
Fixed missing row count when filter box is first opened.

### DIFF
--- a/foqus_lib/gui/flowsheet/dataBrowserFrame.py
+++ b/foqus_lib/gui/flowsheet/dataBrowserFrame.py
@@ -209,6 +209,7 @@ class dataBrowserFrame(_dataBrowserFrame, _dataBrowserFrameUI):
 
         self.updateFilterBox()
         self.tableView.setModel(dataModel(self.results, self))
+        self.numRowsBox.setText(str(self.results.count_rows(filtered=True)))
 
     def autoResizeCols(self):
         # if you resize the columns before showing Qt seems to
@@ -345,10 +346,8 @@ class dataBrowserFrame(_dataBrowserFrame, _dataBrowserFrameUI):
             print "error"
         else:
             self.results.set_filter(filterName)
-        self.tableView.setModel(
-            dataModel(self.results, self))
-        self.numRowsBox.setText(str(
-            self.results.count_rows(filtered=True)))
+        self.tableView.setModel(dataModel(self.results, self))
+        self.numRowsBox.setText(str(self.results.count_rows(filtered=True)))
 
     def saveResultsToCSV(self):
         if self.results is None or self.results.empty:


### PR DESCRIPTION
Fixes issue #208.  Just fixed the row count not appearing. Don't want to default filter to all because there is a chance it may not exist.  