### PR TITLE
Updated Turbine configuration: FOQUS considers Aspen simulation successful even if there is error in Aspen

### DIFF
--- a/foqus_lib/framework/sim/turbineConfiguration.py
+++ b/foqus_lib/framework/sim/turbineConfiguration.py
@@ -1129,8 +1129,8 @@ class turbineConfiguration():
         comProb = False
         res = None
         state = 'submit' #initial state of the job
-        failedStates = ['error', 'expired', 'cancel', 'terminate']
-        succesStates = ['success', 'warning']
+        failedStates = ['expired', 'cancel', 'terminate']
+        succesStates = ['error', 'success', 'warning']
         while True: # start status checking loop
             # wait checkInt seconds wait before checking first time,
             #probably started the job, and it won't finish instantly


### PR DESCRIPTION
I updated turbineConfiguration.py, such that FOQUS will consider an Aspen Plus simulation to be successful, even though the Aspen Plus simulation reports to the user that the simulation completed with warnings and/or errors.