### PR TITLE
SSH Option and Readme Files for Tests

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,6 +15,7 @@ It is possible to install git through Anaconda: ``conda install git``
 
 * Clone the FOQUS repository.
 * Install FOQUS: ``python setup.py develop``
+	* If SSH is needed/desired install FOQUS with the SSH option: ``python setup.py develop ssh``
 
 ## Install Optional Software
 

--- a/examples/Smoke Tests/README.md
+++ b/examples/Smoke Tests/README.md
@@ -1,0 +1,13 @@
+# Smoke Tests for Automated Testing of FOQUS
+
+Tests include: Flowsheet, Optimization, Optimization Under Uncertainty, and Uncertainty Quantification
+
+## Using The Tests
+* Navigate to the main directory containing the ``foqus.py`` file
+* Launch FOQUS with the ``-s`` option: ``python foqus.py -s "examples\Smoke Tests\generic_smoke_test.py"``
+
+## Viewing Results
+* These smoke tests are designed to report errors
+	* Successful runs will not generate error log files
+* Error logs are located in the FOQUS working directory labeled AutoErrLog_testName.txt
+	* Log files include the full error message including headings and supplementary content

--- a/foqus_env_ssh.yml
+++ b/foqus_env_ssh.yml
@@ -1,0 +1,23 @@
+name: foqus_env
+channels:
+  - javascript
+  - conda-forge
+dependencies:
+  - python=2.7
+  - pip
+  - numpy
+  - pandas=0.21
+  - boto3
+  - pyparsing
+  - requests
+  - matplotlib=2.0.0
+  - scipy
+  - numpy
+  - pyqt
+  - pywin32
+  - nlopt
+  - pip:
+    - Flask-Testing
+    - cma
+    - adodbapi
+    - python-ntlm

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,19 @@ See LICENSE.md for license and copyright details.
 """
 from __future__ import print_function
 from setuptools import setup, find_packages
+import sys
 import os
 
+if "ssh" in sys.argv:
+    connectType = 'ssh'
+    sys.argv.remove("ssh")
+elif "https" in sys.argv:
+    connectType = 'https'
+    sys.argv.remove("https")
+else:
+    connectType = 'https'
+        
+    
 # Add build number file to help if BUILD_NUMBER env var is set
 # this is mostly for building on Jenkins, but you could set the
 # env var on a local setup too.  If build number doesn't exist
@@ -40,8 +51,10 @@ install_requires=[
     'pandas>0.20'],
 
 #dependency_links=[]
-dependency_links=['git+https://github.com/CCSI-Toolset/turb_client@2.0.0-alpha#egg=TurbineClient']
-#dependency_links=['git+ssh://git@github.com/CCSI-Toolset/turb_client@2.0.0-alpha#egg=TurbineClient']
+if connectType == 'https':
+    dependency_links=['git+https://github.com/CCSI-Toolset/turb_client@2.0.0-alpha#egg=TurbineClient']
+elif connectType == 'ssh':
+    dependency_links=['git+ssh://git@github.com/CCSI-Toolset/turb_client@2.0.0-alpha#egg=TurbineClient']
 
 # Set all the package parameters
 pkg_name             = "foqus"

--- a/test/auto_test/README.md
+++ b/test/auto_test/README.md
@@ -1,0 +1,19 @@
+# Bash Scripts for Automated Testing of FOQUS
+
+Tests include: Flowsheet, Optimization, Optimization Under Uncertainty, and Uncertainty Quantification
+
+## Using The Scripts
+The scripts are designed to be run in series on a testing machine, but can be run locally if desired. Windows requires a bash shell to run these scripts which can be provided by the Git client.
+The order for using the scripts is listed here:
+* Create
+* Activate
+* Setup
+* Test Scripts
+* Deactivate
+* Destroy
+
+## Viewing Results
+* The smoke tests are designed to report errors
+	* Successful runs will not generate error log files
+* Error logs are located in the FOQUS working directory labeled AutoErrLog_testName.txt
+	* Log files include the full error message including headings and supplementary content

--- a/test/auto_test/foqus_setup_ssh.sh
+++ b/test/auto_test/foqus_setup_ssh.sh
@@ -1,0 +1,2 @@
+cd ../..
+python setup.py develop ssh


### PR DESCRIPTION
I've modified the setup file to accept an ssh option allowing the user to easily switch to ssh if desired. If no additional options are included the setup defaults to https (normal behavior). With this change I've edited the install documentation to include instructions for how to use this option.

I've added readme files for the smoke tests and the testing scripts and an ssh version of the setup script that incorporates this option.

This should solve #161 