### PR TITLE
Fix failing to read input var data type from simsinter

### DIFF
--- a/foqus_lib/framework/graph/node.py
+++ b/foqus_lib/framework/graph/node.py
@@ -365,6 +365,7 @@ class Node():
                     vdflt = item.get("default", None),
                     unit = str(item.get("units", "")),
                     vst = "sinter",
+                    dtype = dtype,
                     vdesc = str(item.get("description", "")),
                     tags = [])
             #Add outputs


### PR DESCRIPTION
Since the type defaults to float, string variables would run into problems setting values from the sinter cofig.