### PR TITLE
Small correction on how to get the online docs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -74,7 +74,7 @@ R is a software toolbox for statistical computing and graphics. R version 3.1+ a
 
 ### Install online documentation
 
-* Download the [HTML documentation](https://github.com/CCSI-Toolset/foqus/releases/download/1.0.0/FOQUS_User_Manual_HTML.zip).
+* Download the `FOQUS_User_Manual_HTML.zip` file from the [latest release](https://github.com/CCSI-Toolset/FOQUS/releases/latest).
 * Extract html documentation and copy the files to foqus_lib/help/html.
 
 ## Optional FOQUS Settings


### PR DESCRIPTION
This was linking to an old release.  The docs may not have changed since then, but linking this way will point people to the latest release, in the even the docs do change!

Also, does a user really need to download the zip file, then copy the contents into a subdir to get the on-line docs?  That seems like something that could be made easier.