### PR TITLE
Add Warning Message Swithcing to Remote or Local Turbine

### DIFF
--- a/foqus.py
+++ b/foqus.py
@@ -4,9 +4,6 @@
 John Eslick, Carnegie Mellon University, 2014
 See LICENSE.md for license and copyright details.
 """
-from __future__ import division  # No integer division
-from __future__ import print_function  # Python 3 style print
-from __future__ import absolute_import  # disable implicit relative imports
 
 # Imports
 import signal

--- a/foqus_lib/gui/main/settingsFrame.py
+++ b/foqus_lib/gui/main/settingsFrame.py
@@ -71,6 +71,18 @@ class settingsFrame(_settingsFrame, _settingsFrameUI):
         self.TestTurb.clicked.connect(self.turbineTest)
         self.testLite.clicked.connect(self.turbineLiteTest)
         self.changePort.clicked.connect(self.updateTurbineLitePort)
+        self.runMethodCombo.currentIndexChanged.connect(
+            self.displayAvailablityWarning)
+
+    def displayAvailablityWarning(self):
+        """
+        Warn that changing the Turbine server means that a different set of
+        simulations may be available and they may not match your flowsheet
+        """
+        QMessageBox.warning(self, "Warning", "You are changing the Turbine server"
+            " connection.  The the new server may not have the simulations or"
+            " correct versions of simulations for your flowsheet.  Please upload"
+            " or update simluations on Turbine as necessary.")
 
     def updateTurbineLitePort(self):
         """


### PR DESCRIPTION
Add warning message about simulation possibly not being available when switching between local and remote.  Issue #27 