### PR TITLE
Change Filter Method to Use Calculated Columns

### DIFF
--- a/foqus_lib/framework/sampleResults/results.py
+++ b/foqus_lib/framework/sampleResults/results.py
@@ -18,17 +18,15 @@ from collections import OrderedDict
 
 class dataFilter(object):
 
-    def __init__(self, no_results=False, lock=False):
+    def __init__(self, no_results=False):
         self.filterTerm = None       # list of columns to filter by
         self.sortTerm = None         # list of columns to sort by
         self.no_results = no_results # if true return no matches
-        self.lock = lock
 
     def saveDict(self):
         sd = {'filterTerm':self.filterTerm,
               'sortTerm':self.sortTerm,
-              'self.no_results':self.no_results,
-              'self.lock':self.lock}
+              'no_results':self.no_results}
         return sd
 
     def loadDict(self, sd):
@@ -121,7 +119,7 @@ def search_term_list(st):
                 'terms, enclose the column names in "". See log for deatils')
     else:
         if st.startswith('"'):
-            ft = json.loads(st)
+            st = json.loads(st)
         st = [st]
     ascend = [True]*len(st)
     for i, t in enumerate(st):

--- a/foqus_lib/gui/flowsheet/dataFilterDialog.py
+++ b/foqus_lib/gui/flowsheet/dataFilterDialog.py
@@ -34,50 +34,13 @@ class dataFilterDialog(_dataFilterDialog, _dataFilterDialogUI):
             self.results = self.dat.flowsheet.results
         else:
             self.results = results
-
+        self.colList.itemDoubleClicked.connect(self.copyCol2)
         self.newFilterButton.clicked.connect(self.addFilter)
         self.deleteFilterButton.clicked.connect(self.delFilter)
-        self.addOpButton.clicked.connect(self.addOp)
-        self.addRuleButton.clicked.connect(self.addRule)
         self.doneButton.clicked.connect(self.doneClicked)
-        #self.copyButton.clicked.connect(self.copyCol)
-        self.colList.itemDoubleClicked.connect(self.copyCol2)
-        self.muButton.clicked.connect(self.moveUp)
-        self.mdButton.clicked.connect(self.moveDown)
-        self.sortCheck.clicked.connect(self.enableSortTerm)
-        self.deleteButton.clicked.connect(self.deleteRows)
-        self.selectFilterBox.currentIndexChanged.connect(
-            self.selectFilter)
-        self.copList = ["NOT", "AND", "OR", "XOR"]
-        self.ropList = ["=", "!=", "<", ">", "<=", ">=", "IN", "APPROX"]
-        self.ropDict = {
-            "=":dataFilterRule.OP_EQ,
-            "!=":dataFilterRule.OP_NEQ,
-            "<":dataFilterRule.OP_L,
-            ">":dataFilterRule.OP_G,
-            "<=":dataFilterRule.OP_LE,
-            ">=":dataFilterRule.OP_GE,
-            "IN":dataFilterRule.OP_IN,
-            "APPROX":dataFilterRule.OP_AEQ}
-        self.copDict = {
-            "NOT":dataFilter.DF_NOT,
-            "AND":dataFilter.DF_AND,
-            "OR":dataFilter.DF_OR,
-            "XOR":dataFilter.DF_XOR}
-        self.ropDictRev = {}
-        for key, item in self.ropDict.items():
-            self.ropDictRev[item] = key
-        self.copDictRev = {}
-        for key, item in self.copDict.items():
-            self.copDictRev[item] = key
         self.updateFilterBox()
         self.updateForm()
         self.prevFilter = None
-        self.split = QSplitter(self.splitFrame)
-        self.split.addWidget(self.ruleTable)
-        self.split.addWidget(self.TreeFrame)
-        self.splitFrame.layout().addWidget(self.split)
-        self.splitFrame.layout().activate()
         headings = self.results.columns
         self.colList.addItems(headings)
 
@@ -87,108 +50,7 @@ class dataFilterDialog(_dataFilterDialog, _dataFilterDialogUI):
     def copyCol2(self, ci=None):
         clipboard = QApplication.clipboard()
         if ci is not None:
-            clipboard.setText(ci.text())
-
-    def enableSortTerm(self):
-        if self.sortCheck.isChecked():
-            self.sortTermEdit.setEnabled(True)
-        else:
-            self.sortTermEdit.setEnabled(False)
-
-    def selectedRows(self):
-        items = self.ruleTable.selectedItems()
-        rows = set()
-        for item in items:
-            rows.add(item.row())
-        return rows
-
-    def rowSwap(self, row1, row2):
-        table = self.ruleTable
-        row1Items = [
-            table.takeItem(row1, 0),
-            table.cellWidget(row1, 1),
-            table.takeItem(row1, 2)]
-        row2Items = [
-            table.takeItem(row2, 0),
-            table.cellWidget(row2, 1),
-            table.takeItem(row2, 2)]
-        table.setItem(row1, 0, row2Items[0])
-        table.setItem(row2, 0, row1Items[0])
-        table.setItem(row1, 2, row2Items[2])
-        table.setItem(row2, 2, row1Items[2])
-        r1ct = row1Items[1].currentText()
-        r2ct = row2Items[1].currentText()
-        r1it = [row1Items[1].itemText(i) \
-            for i in range(row1Items[1].count())]
-        r2it = [row2Items[1].itemText(i) \
-            for i in range(row2Items[1].count())]
-        #assigning new widgets will delete old
-        gh.setTableItem(table, row1, 1, r2ct, pullDown=r2it)
-        gh.setTableItem(table, row2, 1, r1ct, pullDown=r1it)
-
-    def moveUp(self):
-        rows = self.selectedRows()
-        if len(rows) == 0:
-            return
-        row = sorted(rows)[0]
-        if row == 0:
-            row2 = self.ruleTable.rowCount() - 1
-        else:
-            row2 = row-1
-        self.rowSwap(row, row2)
-        self.ruleTable.clearSelection()
-        self.ruleTable.selectRow(row2)
-
-    def moveDown(self):
-        rows = self.selectedRows()
-        if len(rows) == 0:
-            return
-        row = sorted(rows)[0]
-        if row == self.ruleTable.rowCount() - 1:
-            row2 = 0
-        else:
-            row2 = row+1
-        self.rowSwap(row, row2)
-        self.ruleTable.clearSelection()
-        self.ruleTable.selectRow(row2)
-
-    def deleteRows(self):
-        rows = list(self.selectedRows())
-        rows = reversed(sorted(rows))
-        self.ruleTable.clearSelection()
-        for row in rows:
-            self.ruleTable.removeRow(row)
-
-    def addOp(self, op=None):
-        r = self.results
-        if op is not None:
-            op = self.copDictRev[op]
-        else:
-            op="AND"
-        table = self.ruleTable
-        row = table.rowCount()
-        table.setRowCount(row + 1)
-        bg = QColor(200, 200, 200)
-        gh.setTableItem(table, row, 0, "", bgColor=bg, editable=False)
-        gh.setTableItem(table, row, 2, "", bgColor=bg, editable=False)
-        gh.setTableItem(table, row, 1, op, pullDown=self.copList)
-
-    def addRule(self, rule=None):
-        r = self.results
-        if rule:
-            term1 = json.dumps(rule.term1)
-            term2 = json.dumps(rule.term2)
-            op = self.ropDictRev[rule.op]
-        else:
-            term1 = "err"
-            term2 = "0"
-            op = "="
-        table = self.ruleTable
-        row = table.rowCount()
-        table.setRowCount(row + 1)
-        gh.setTableItem(table, row, 0, term1, editable=True)
-        gh.setTableItem(table, row, 2, term2, editable=True)
-        gh.setTableItem(table, row, 1, op, pullDown=self.ropList)
+            clipboard.setText('"{}"'.format(ci.text()))
 
     def doneClicked(self):
         self.applyChanges()
@@ -231,9 +93,8 @@ class dataFilterDialog(_dataFilterDialog, _dataFilterDialogUI):
                 self.results.filters[newName] = \
                     dataFilter()
         self.updateFilterBox(newName)
-        self.ruleTable.setRowCount(0)
 
-    def updateFilterBox(self, fltr = None):
+    def updateFilterBox(self, fltr=None):
         '''
             Update the list of filters in the combo box
         '''
@@ -250,25 +111,13 @@ class dataFilterDialog(_dataFilterDialog, _dataFilterDialogUI):
         self.prevFilter = self.selectFilterBox.currentText()
 
     def updateForm(self):
-        self.ruleTable.setRowCount(0)
         fltrName = self.selectFilterBox.currentText()
-        if fltrName == None or fltrName == "":
-            return
-        r = self.results
-        f = r.filters[fltrName]
-        self.sortCheck.setChecked(f.sortTerm != None)
-        if f.sortTerm:
-            self.sortTermEdit.setText(str(f.sortTerm))
-        self.enableSortTerm()
-        for item in f.fstack:
-            if item[0] < f.DF_END_OP:
-                self.addOp(item[0])
-            elif item[0] == f.DF_RULE:
-                self.addRule(item[1])
-            else:
-                raise Exception("unknown filter item")
+        fltr = self.results.filters[fltrName]
+        self.sortTermEdit.setText(fltr.sortTerm)
+        self.filterTermEdit.setText(fltr.filterTerm)
+        self.noResultsCheckBox.setChecked(fltr.no_results)
 
-    def applyChanges(self, usePrev = False):
+    def applyChanges(self, usePrev=False):
         if usePrev:
             fltrName = self.prevFilter
         else:
@@ -278,34 +127,7 @@ class dataFilterDialog(_dataFilterDialog, _dataFilterDialogUI):
         r = self.results
         r.filters[fltrName] = dataFilter()
         fltr = r.filters[fltrName]
-        if self.sortCheck.isChecked():
-            fltr.sortTerm = self.sortTermEdit.text()
-        else:
-            fltr.sortTerm = None
-        table = self.ruleTable
-        for row in range(table.rowCount()):
-            term1 = gh.getCellText(table, row, 0)
-            term2 = gh.getCellText(table, row, 2)
-            op = gh.getCellText(table, row, 1)
-            if term1 == "" and term2 == "" and op in self.copList:
-                # operator that operates on rules.
-                op = self.copDict[op]
-                fltr.fstack.append([op])
-            elif term1 != "" and term2 != "" and op in self.ropList:
-                # rule
-                rule = dataFilterRule()
-                try:
-                    rule.term1 = json.loads(term1)
-                except ValueError:
-                    rule.term1 = term1
-                try:
-                    rule.term2 = json.loads(term2)
-                except ValueError:
-                    rule.term2 = term2
-                rule.op = self.ropDict[op]
-                fltr.fstack.append([dataFilter.DF_RULE, rule])
-            else:
-                #something wrong
-                print("message box here")
-                return 1
+        fltr.sortTerm = self.sortTermEdit.text()
+        fltr.filterTerm = self.filterTermEdit.text()
+        fltr.no_results = self.noResultsCheckBox.isChecked()
         return 0

--- a/foqus_lib/gui/flowsheet/dataFilterDialog_UI.ui
+++ b/foqus_lib/gui/flowsheet/dataFilterDialog_UI.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>787</width>
+    <width>666</width>
     <height>411</height>
    </rect>
   </property>
@@ -19,7 +19,7 @@
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
@@ -69,189 +69,63 @@
     </layout>
    </item>
    <item>
-    <widget class="QFrame" name="splitFrame">
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_5">
-      <item>
-       <widget class="QTableWidget" name="ruleTable">
-        <column>
-         <property name="text">
-          <string>Term 1</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>Operator</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>Term 2</string>
-         </property>
-        </column>
-       </widget>
-      </item>
-      <item>
-       <widget class="QFrame" name="TreeFrame">
-        <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>Columns (double click to copy)</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QListWidget" name="colList"/>
-         </item>
-        </layout>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QCheckBox" name="sortCheck">
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="3" column="0">
+      <widget class="QCheckBox" name="noResultsCheckBox">
        <property name="text">
-        <string>Sort Data</string>
+        <string>No Results</string>
        </property>
       </widget>
      </item>
-     <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
+     <item row="2" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
-        <string>Sort term:</string>
-       </property>
-       <property name="buddy">
-        <cstring>sortTermEdit</cstring>
+        <string>Sort by column(s):</string>
        </property>
       </widget>
      </item>
-     <item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Filter by column(s):</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QLineEdit" name="filterTermEdit">
+       <property name="text">
+        <string>[]</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
       <widget class="QLineEdit" name="sortTermEdit">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>200</width>
-         <height>16777215</height>
-        </size>
+       <property name="text">
+        <string>[]</string>
        </property>
       </widget>
      </item>
-     <item>
-      <spacer name="horizontalSpacer_4">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+     <item row="3" column="2">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Filter out all results</string>
        </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
+      </widget>
      </item>
     </layout>
    </item>
    <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Columns (Double-Click to Copy)</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QListWidget" name="colList"/>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QPushButton" name="addRuleButton">
-       <property name="text">
-        <string>Add Rule</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../icons.qrc">
-         <normaloff>:/icons/icons/add.svg</normaloff>:/icons/icons/add.svg</iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="addOpButton">
-       <property name="text">
-        <string>Add Operation</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../icons.qrc">
-         <normaloff>:/icons/icons/add.svg</normaloff>:/icons/icons/add.svg</iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="muButton">
-       <property name="text">
-        <string>Move Up</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../icons.qrc">
-         <normaloff>:/icons/icons/up.svg</normaloff>:/icons/icons/up.svg</iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="mdButton">
-       <property name="text">
-        <string>Move Down</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../icons.qrc">
-         <normaloff>:/icons/icons/down.svg</normaloff>:/icons/icons/down.svg</iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="deleteButton">
-       <property name="text">
-        <string>Delete</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../icons.qrc">
-         <normaloff>:/icons/icons/delete.svg</normaloff>:/icons/icons/delete.svg</iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="showColButton">
-       <property name="text">
-        <string>Show Columns</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../icons.qrc">
-         <normaloff>:/icons/icons/search.svg</normaloff>:/icons/icons/search.svg</iconset>
-       </property>
-      </widget>
-     </item>
      <item>
       <spacer name="horizontalSpacer_2">
        <property name="orientation">

--- a/foqus_lib/gui/flowsheet/dataFilterDialog_UI.ui
+++ b/foqus_lib/gui/flowsheet/dataFilterDialog_UI.ui
@@ -77,13 +77,6 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="3" column="0">
-      <widget class="QCheckBox" name="noResultsCheckBox">
-       <property name="text">
-        <string>No Results</string>
-       </property>
-      </widget>
-     </item>
      <item row="2" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
@@ -94,17 +87,17 @@
      <item row="0" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
-        <string>Filter by column(s):</string>
+        <string>Filter expression:</string>
        </property>
       </widget>
      </item>
      <item row="0" column="2">
       <widget class="QLineEdit" name="filterTermEdit">
        <property name="toolTip">
-        <string>This is a json string list of column names, or a single column name.  This filter will show results where this list of columns combined with AND evaluates to True.  The usual way to filter data would be to create calculated columns with logical expressions.</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Logical Python expression.  The filter will include rows that evaluate to True.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="text">
-        <string>[]</string>
+        <string/>
        </property>
       </widget>
      </item>
@@ -115,13 +108,6 @@
        </property>
        <property name="text">
         <string>[]</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="2">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string>return no results</string>
        </property>
       </widget>
      </item>

--- a/foqus_lib/gui/flowsheet/dataFilterDialog_UI.ui
+++ b/foqus_lib/gui/flowsheet/dataFilterDialog_UI.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>666</width>
+    <width>729</width>
     <height>411</height>
    </rect>
   </property>
@@ -66,6 +66,13 @@
        </property>
       </spacer>
      </item>
+     <item>
+      <widget class="QPushButton" name="addCalcButton">
+       <property name="text">
+        <string>New Calculated Column</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>
@@ -93,6 +100,9 @@
      </item>
      <item row="0" column="2">
       <widget class="QLineEdit" name="filterTermEdit">
+       <property name="toolTip">
+        <string>This is a json string list of column names, or a single column name.  This filter will show results where this list of columns combined with AND evaluates to True.  The usual way to filter data would be to create calculated columns with logical expressions.</string>
+       </property>
        <property name="text">
         <string>[]</string>
        </property>
@@ -100,6 +110,9 @@
      </item>
      <item row="2" column="2">
       <widget class="QLineEdit" name="sortTermEdit">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is a json list of columns to sort by.  If rows have the same value in the first column the second will be used to sort and so on.  If a &amp;quot;-&amp;quot; is included at the begining of a column name string (inside quotes), that columns will be sorted in descending order.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
        <property name="text">
         <string>[]</string>
        </property>
@@ -108,21 +121,33 @@
      <item row="3" column="2">
       <widget class="QLabel" name="label_4">
        <property name="text">
-        <string>Filter out all results</string>
+        <string>return no results</string>
        </property>
       </widget>
      </item>
     </layout>
    </item>
    <item>
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Columns (Double-Click to Copy)</string>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
+     <property name="title">
+      <string>Columns (Drag and Drop or Double-Click to Copy)</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QListWidget" name="colList">
+        <property name="showDropIndicator" stdset="0">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
-   </item>
-   <item>
-    <widget class="QListWidget" name="colList"/>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">


### PR DESCRIPTION
This is an update to make filtering easier to understand.  We will need to update the documentation at some point though.  This could break some of @CSRussell2319's tests if there are filter tests.

This is related to issue #312 

The box for a filter now takes a Python expression.  This expression should return a numpy array or list that has the same number of elements as rows in the data table where each entry is true or false.  True to include a row false to exclude it.  The syntax is the same as calculated columns.  There is a c("my_column") function that returns a numpy array of values in my_column. You can write your Python expression how you want, but I recommend numpy logic functions https://docs.scipy.org/doc/numpy-1.15.1/reference/routines.logic.html.  Numpy is imported as np.

Examples  using Rosenbrock_no_vectors.foqus.

No errors and x1 > 0:

```python
np.logical_and(c("input.Rosenbrock.x1") > 0, c("err") == 0)
```
x2 > 0 and x1 > 0:

```python
np.logical_and(c("input.Rosenbrock.x1") > 0, c("input.Rosenbrock.x2") > 0)
```
x2 > 0 or x1 > 0:

```python
np.logical_or(c("input.Rosenbrock.x1") > 0, c("input.Rosenbrock.x2") > 0)
```

If you are careful with parentheses and make sure the arrays you are doing logical operations on contain strictly boolean values you can still use Python's binary operators, but be careful it's easy to get an exception or a strange result.  If you get an exception you can just go back and edit the filter.  The "and" and "or" operators will cause Numpy to raise and exception about "the truth value of an array with more than one element," so if you see that you know what you did.  These examples also work but are more error prone and less recommended.

 No errors and x1 > 0:

```python
(c("input.Rosenbrock.x1") > 0) & (c("err") == 0)
```

x2 > 0 and x1 > 0:

```python
(c("input.Rosenbrock.x1") > 0) & c("input.Rosenbrock.x2") > 0)
```
x2 > 0 or x1 > 0:

```python
(c("input.Rosenbrock.x1") > 0) | (c("input.Rosenbrock.x2") > 0)
```



   

 