### PR TITLE
Batch File and requirements.txt

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,7 +12,8 @@ you can skip steps 1 to 4.
 3. Set up a foqus environment.
   > conda create -n foqus -python=3
 4. Activate the environment
-  > source activate foqus
+  - Linux: > source activate foqus
+  - Windows: > conda activate foqus
 
 If you create an environment in which to install FOQUS, you will need to ensure that environment is active before running FOQUS.
 
@@ -30,16 +31,17 @@ There are 2 ways to get FOQUS either download it from the [github page](https://
 
 ## Install FOQUS
 
-8. There are two ways to install FOQUS.  The first one is in-place with will leave the FOQUS source where it is and any changes made to these files will result in changes to FOQUS.  This mode is often used by developers but it can be convenient for other users. The other option is to do a regular install which copies compiled FOQUS files to a central Python package location.
+8. Install requirements
+  - > ```pip install -r requirements.txt```
+9. There are two ways to install FOQUS.  The first one is in-place which will leave the FOQUS source where it is and any changes made to these files will result in changes to the installed version of FOQUS.  This mode is often used by developers but it can be convenient for other users. The other option is to do a regular install which copies compiled FOQUS files to a central Python package location.
   - install in-place
     - > ``python setup.py develop``
-    - or if you need to download dependencies over ssh
-    - > ``python setup.py develop ssh``
   - regular install
     - > ``python setup.py install``
-    - or if you need to download dependencies over ssh
-    - > ``python setup.py develop ssh``
 
+On Windows, the setup.py script creates a foqus.bat file which will activate the correct conda environment (if installed in a conda environment) then run the foqus.py script.  The batch file assumes that "python" can be found in a location in the  PATH environment variable.  If you are using a conda environment, part of activating the environment is adding the correct Python interpretor location to the exec path. If you are not using a conda environment, and "python" is not in your exec path, you may want to edit the batch file to include the full Python interpretor path or add the directory to PATH.  The batch file can be relocated to a convenient location, and you can add windows shortcuts to launch it.
+
+On Linux and OSX, activate the conda environment if necessary by entering the commend ```source activate <environment where FOQUS is installed>``` in terminal.  The foqus.py script should be in the executable path so just running ```foqus.py``` should run FOQUS.
 
 ## Install Optional Software
 

--- a/foqus_lib/framework/sim/turbineLiteDB.py
+++ b/foqus_lib/framework/sim/turbineLiteDB.py
@@ -10,7 +10,7 @@ import os
 import threading
 import adodbapi
 import adodbapi.apibase
-adodbapi.adodbapi.defaultCursorLocation = adodbapi.adUseServer
+adodbapi.adodbapi.defaultCursorLocation = 2 #adodbapi.adUseServer
 
 class DBException(Exception):
     pass

--- a/requirments.txt
+++ b/requirments.txt
@@ -1,0 +1,12 @@
+python-dateutil==2.5.0
+PyQt5
+sip
+matplotlib
+scipy
+numpy
+cma
+tqdm
+pandas>0.20
+adodbapi>=2.6.0.7; sys_platform == 'win32'
+pywin32; sys_platform == 'win32'
+git+https://git@github.com/CCSI-Toolset/turb_client

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ from setuptools import setup, find_packages
 import sys
 import os
 import subprocess
+import shutil
 
 # default_version is the version if "git describe --tags" falls through
 # Addtional package info is set in foqus_lib/version/version.template.
@@ -19,15 +20,6 @@ try:
 except:
     version=default_version
 
-if "ssh" in sys.argv:
-    connectType = 'ssh'
-    sys.argv.remove("ssh")
-elif "https" in sys.argv:
-    connectType = 'https'
-    sys.argv.remove("https")
-else:
-    connectType = 'https'
-
 # Write the version module
 with open("foqus_lib/version/version.template", 'r') as f:
     verfile = f.read()
@@ -39,28 +31,7 @@ with open("foqus_lib/version/version.py", 'w') as f:
 import foqus_lib.version.version as ver
 print("Setting version as {0}".format(ver.version))
 
-install_requires=[
-    'TurbineClient',
-    'PyQt5',
-    'sip',   # not sure if I need this
-    'matplotlib',
-    'scipy',
-    'numpy',
-    'cma',
-    'tqdm',
-    'pandas>0.20']
-
-if os.name == 'nt':
-    install_requires.append("adodbapi>=2.6.0.7")
-    install_requires.append("pywin32")
-
-dependency_links=[]
-if connectType == 'https':
-    dependency_links=['git+https://git@github.com/CCSI-Toolset/turb_client.git#egg=TurbineClient']
-elif connectType == 'ssh':
-    dependency_links=['git+ssh://git@github.com/CCSI-Toolset/turb_client.git#egg=TurbineClient']
-
-setup(
+dist = setup(
     name = ver.name,
     version = ver.version,
     license = ver.license,
@@ -79,22 +50,53 @@ setup(
         'foqus.py',
         'cloud/aws/foqus_worker.py',
         'cloud/aws/foqus_service.py',
-        'icons_rc.py'],
-    install_requires=install_requires,
-    dependency_links=dependency_links
+        'icons_rc.py']
 )
 
-print("\n\n\n")
-print("==============================================================")
-print("The following packages can be installed by the user")
-print("==============================================================")
-print("PSUADE (Required for UQ features): ")
-print("    https://github.com/LLNL/psuade\n")
-print("Turbine (Windows only, run Aspen, Excel, and gPROMS): ")
-print("    (url tbd)\n")
-print("ALAMO (ALAMO Surogate models): ")
-print("    (url tbd)\n")
-print("NLOpt Python (Additional optimization solvers):")
-print("    https://nlopt.readthedocs.io/en/latest/NLopt_Installation/\n")
-print("==============================================================")
-print("\n")
+if os.name == 'nt': # Write a batch file on windows to make it easier to launch
+    #first see if this is a conda env
+    foqus_path = subprocess.check_output(
+        ["where", "$PATH:foqus.py"]).decode('utf-8').split("\n")[0].strip()
+    if "CONDA_DEFAULT_ENV" in os.environ:
+        #we're using conda
+        env = os.environ["CONDA_DEFAULT_ENV"]
+        conda_path = shutil.which("conda")
+    else:
+        env = None
+    with open("foqus.bat", 'w') as f:
+        if env is not None:
+            f.write('cmd /c "{} activate {} && python {}'\
+                .format(conda_path, env, foqus_path))
+        else:
+            f.write('"cmd /c python {}"\n'.format(foqus_path))
+
+print("""
+
+==============================================================
+**Installed FOQUS {}**
+
+**Optional addtional sotfware**
+
+PSUADE (Required for UQ features):
+   https://github.com/LLNL/psuade
+
+Turbine (Windows only, run Aspen, Excel, and gPROMS):
+    https://github.com/CCSI-Toolset/turb_sci_gate/releases
+
+ALAMO (ALAMO Surogate models):
+    http://archimedes.cheme.cmu.edu/?q=alamo
+
+NLOpt Python (Additional optimization solvers):
+    https://nlopt.readthedocs.io/en/latest/NLopt_Installation/
+
+**Batch file/Running FOQUS**
+
+Linux:
+    Run the command
+    > foqus.py
+
+Windows:
+    On Windows, this script makes a batch file to run FOQUS.
+    This batch file can be placed in any conveinient location.
+==============================================================
+""".format(ver.version))

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,8 @@ default_version = "3.0.0"
 try:
     version=subprocess.check_output(
         ["git", "describe", "--tags"]).decode('utf-8').strip()
+    version = version.replace("-", ".dev", 1)
+    version = version.replace("-", "+", 1)
 except:
     version=default_version
 


### PR DESCRIPTION
I added requirements.txt which I hope will fix the weird import errors that we were getting with requirements installed from setup.py.  Installing those added a step to the install instructions.

I also took a shot at generating a batch file on windows at the end of setup.py.  It works good for me, but several people will probably need to try it to ensure it works for different setups.  I think as long as it looks reasonable it's probably fine to merge then test.

I also dropped the enumerated type value that was causing problems  with adodbapi.  I don't know why sometimes the enum is there sometimes and not others.  Maybe if has something to do with where you get your pacakages, but I replaced it with the number to avoid problems.

@boverhof, I added python-dateutil==2.5.0 to requirements because I have a problem where the latest version makes TurbineClient complain about the version being to old.  They may have removed something you are using.  