### PR TITLE
fixing issue with creating directories in Windows OS

### DIFF
--- a/foqus_lib/gui/sdoe/sdoeAnalysisDialog.py
+++ b/foqus_lib/gui/sdoe/sdoeAnalysisDialog.py
@@ -310,7 +310,7 @@ class sdoeAnalysisDialog(_sdoeAnalysisDialog, _sdoeAnalysisDialogUI):
         return min_vals, max_vals, include_list
 
     def writeConfigFile(self, test=False):
-        timestamp = datetime.now().isoformat()
+        timestamp = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
         outdir = os.path.join(self.dname, timestamp)
         os.makedirs(outdir, exist_ok=False)
         configFile = os.path.join(outdir, 'config.ini')


### PR DESCRIPTION
Small change in the datetime format to create directories since it was causing some issues in Windows OS. Should take care of issue #378 