### PR TITLE
Clear tables in init in case there are some extra rows in the ui file.

### DIFF
--- a/foqus_lib/gui/sinter/sinter_config.py
+++ b/foqus_lib/gui/sinter/sinter_config.py
@@ -37,6 +37,9 @@ class SinterConfigMainWindow(_sinterConfigUI, _sinterConfig):
         self.outputs_table.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.inputs_table.setSelectionBehavior(QAbstractItemView.SelectRows)
         self.input_files_table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.inputs_table.setRowCount(0)
+        self.outputs_table.setRowCount(0)
+        self.input_files_table.setRowCount(0)
         self.show()
 
     def _add_input_file(self):


### PR DESCRIPTION
This just clears some rows in tables that should be empty when the gPROMS sinterconfig gui starts.  I haven't reproduced this, but I saw the inputs-table seemingly start with a couple blank rows for someone else.  This may not fix anything, but at least this PR won't hurt anything. 