### PR TITLE
Fixing make html warnings.

### DIFF
--- a/docs/source/chapt_flowsheet/reference/flowsheet.rst
+++ b/docs/source/chapt_flowsheet/reference/flowsheet.rst
@@ -28,7 +28,7 @@ simultaneously. More advanced solution options will be added if a need
 arises. Figure :ref:`fig.flowsheet.recycle`
 shows how a simple flowsheet with recycle would be solved.
 
-.. _fig.flowsheet.recycle
+.. _fig.flowsheet.recycle:
 .. figure:: ../figs/recycle.svg
    :alt: Flowsheet Recycle
    :name: fig.flowsheet.recycle
@@ -42,7 +42,7 @@ Figure :ref:`fig.flowsheet.editor` illustrates
 the main **Flowsheet Editor** screen and a description of the pieces.
 The toolbar on the left contains various flowsheet tools.
 
-.. _fig.flowsheet.editor`
+.. _fig.flowsheet.editor:
 .. figure:: ../figs/flowsheetEdit.svg
    :alt: Flowsheet Editor
    :name: fig.flowsheet.editor
@@ -123,7 +123,7 @@ The **Node Editor** enables the assignment of simulations to a node, and
 editing variables. Figure :ref:`fig.node.editor.input` shows the Node
 Editor window with the input variables section of the toolbox displayed.
 
-.. _fig.node.editor.input
+.. _fig.node.editor.input:
 .. figure:: ../figs/nodeEditInput.svg
    :alt: Node Editor Window
    :name: fig.node.editor.input
@@ -284,7 +284,7 @@ Figure :ref:`fig.post.calc` illustrates the **Node
 Script** tab of the **Node Editor** with calculations for an
 optimization test problem.
 
-.. _fig.post.calc
+.. _fig.post.calc:
 .. figure:: ../figs/postCalc.svg
    :alt: Node Script Tab
    :name: fig.post.calc
@@ -302,7 +302,7 @@ Edge Editor
 The **Edge Editor** is illustrated in Figure :ref:`fig.edge.editor`. The **Edge Editor** can be
 used to set connections between node variables.
 
-.. _fig.edge.editor
+.. _fig.edge.editor:
 .. figure:: ../figs/edgeEdit.svg
    :alt: Edge Editor
    :name: fig.edge.editor

--- a/docs/source/chapt_flowsheet/reference/flowsheet.rst
+++ b/docs/source/chapt_flowsheet/reference/flowsheet.rst
@@ -28,7 +28,6 @@ simultaneously. More advanced solution options will be added if a need
 arises. Figure :ref:`fig.flowsheet.recycle`
 shows how a simple flowsheet with recycle would be solved.
 
-.. _fig.flowsheet.recycle:
 .. figure:: ../figs/recycle.svg
    :alt: Flowsheet Recycle
    :name: fig.flowsheet.recycle
@@ -42,7 +41,6 @@ Figure :ref:`fig.flowsheet.editor` illustrates
 the main **Flowsheet Editor** screen and a description of the pieces.
 The toolbar on the left contains various flowsheet tools.
 
-.. _fig.flowsheet.editor:
 .. figure:: ../figs/flowsheetEdit.svg
    :alt: Flowsheet Editor
    :name: fig.flowsheet.editor
@@ -123,7 +121,6 @@ The **Node Editor** enables the assignment of simulations to a node, and
 editing variables. Figure :ref:`fig.node.editor.input` shows the Node
 Editor window with the input variables section of the toolbox displayed.
 
-.. _fig.node.editor.input:
 .. figure:: ../figs/nodeEditInput.svg
    :alt: Node Editor Window
    :name: fig.node.editor.input
@@ -284,7 +281,6 @@ Figure :ref:`fig.post.calc` illustrates the **Node
 Script** tab of the **Node Editor** with calculations for an
 optimization test problem.
 
-.. _fig.post.calc:
 .. figure:: ../figs/postCalc.svg
    :alt: Node Script Tab
    :name: fig.post.calc
@@ -302,7 +298,6 @@ Edge Editor
 The **Edge Editor** is illustrated in Figure :ref:`fig.edge.editor`. The **Edge Editor** can be
 used to set connections between node variables.
 
-.. _fig.edge.editor:
 .. figure:: ../figs/edgeEdit.svg
    :alt: Edge Editor
    :name: fig.edge.editor

--- a/docs/source/chapt_flowsheet/reference/results.rst
+++ b/docs/source/chapt_flowsheet/reference/results.rst
@@ -10,7 +10,6 @@ are displayed in a table, and the contents can be copied and pasted into
 a spreadsheet or exported to a CSV file. Figure :ref:`fig.results.table` 
 show the Flowsheet Results Table window.
 
-.. _fig.results.table:
 .. figure:: ../figs/resultsTable.svg
    :alt: Flowsheet Results Table Window
    :name: fig.results.table
@@ -44,7 +43,7 @@ errors are typically caused by a simulation that fails to converge or
 has some other calculation error (e.g., ACM does not converge or an
 Excel spreadsheet simulation with a division by 0 error).
 
-.. _table.fs.error
+.. _table.fs.error:
 .. table:: Flowsheet Error Codes
 
    +------+-----------------------------------------------------------+
@@ -85,7 +84,7 @@ Excel spreadsheet simulation with a division by 0 error).
    | 201  | Cycle in determining calculation order (invalid tear set) |
    +------+-----------------------------------------------------------+
 
-.. _table.node.error
+.. _table.node.error:
 .. table:: Node Error Codes
 
    +------+---------------------------------------+

--- a/docs/source/chapt_flowsheet/reference/results.rst
+++ b/docs/source/chapt_flowsheet/reference/results.rst
@@ -10,7 +10,7 @@ are displayed in a table, and the contents can be copied and pasted into
 a spreadsheet or exported to a CSV file. Figure :ref:`fig.results.table` 
 show the Flowsheet Results Table window.
 
-.. _fig.results.table
+.. _fig.results.table:
 .. figure:: ../figs/resultsTable.svg
    :alt: Flowsheet Results Table Window
    :name: fig.results.table
@@ -44,6 +44,7 @@ errors are typically caused by a simulation that fails to converge or
 has some other calculation error (e.g., ACM does not converge or an
 Excel spreadsheet simulation with a division by 0 error).
 
+.. _table.fs.error
 .. table:: Flowsheet Error Codes
 
    +------+-----------------------------------------------------------+
@@ -84,6 +85,7 @@ Excel spreadsheet simulation with a division by 0 error).
    | 201  | Cycle in determining calculation order (invalid tear set) |
    +------+-----------------------------------------------------------+
 
+.. _table.node.error
 .. table:: Node Error Codes
 
    +------+---------------------------------------+

--- a/docs/source/chapt_flowsheet/reference/settings.rst
+++ b/docs/source/chapt_flowsheet/reference/settings.rst
@@ -14,7 +14,6 @@ The Settings screen displays settings grouped into tabs. Figure
 :ref:`fig.settings.options` shows **Settings,
 FOQUS** tab.
 
-.. _fig.settings.options:
 .. figure:: ../figs/settings_options.svg
    :alt: Settings, FOQUS Tab
    :name: fig.settings.options
@@ -95,7 +94,6 @@ The **Turbine** tab contains settings for configuring the local and
 remote instance of Turbine. Figure :ref:`fig.settings.turbine` shows the FOQUS
 Turbine settings.
 
-.. _fig.settings.turbine:
 .. figure:: ../figs/settings_turbine.svg
    :alt: Settings, Turbine Tab
    :name: fig.settings.turbine
@@ -163,7 +161,6 @@ which provide debugging information. The FOQUS log files are stored in
 the logs directory in the working directory. Figure :ref:`fig.settings.logging` show the FOQUS log
 settings. There are two log files (1) FOQUS and (2) Turbine Client.
 
-.. _fig.settings.logging:
 .. figure:: ../figs/settings_logging.svg
    :alt: Settings, Logging Tab
    :name: fig.settings.logging

--- a/docs/source/chapt_flowsheet/reference/settings.rst
+++ b/docs/source/chapt_flowsheet/reference/settings.rst
@@ -14,7 +14,7 @@ The Settings screen displays settings grouped into tabs. Figure
 :ref:`fig.settings.options` shows **Settings,
 FOQUS** tab.
 
-.. _fig.settings.options
+.. _fig.settings.options:
 .. figure:: ../figs/settings_options.svg
    :alt: Settings, FOQUS Tab
    :name: fig.settings.options
@@ -95,7 +95,7 @@ The **Turbine** tab contains settings for configuring the local and
 remote instance of Turbine. Figure :ref:`fig.settings.turbine` shows the FOQUS
 Turbine settings.
 
-.. _fig.settings.turbine
+.. _fig.settings.turbine:
 .. figure:: ../figs/settings_turbine.svg
    :alt: Settings, Turbine Tab
    :name: fig.settings.turbine
@@ -163,7 +163,7 @@ which provide debugging information. The FOQUS log files are stored in
 the logs directory in the working directory. Figure :ref:`fig.settings.logging` show the FOQUS log
 settings. There are two log files (1) FOQUS and (2) Turbine Client.
 
-.. _fig.settings.logging
+.. _fig.settings.logging:
 .. figure:: ../figs/settings_logging.svg
    :alt: Settings, Logging Tab
    :name: fig.settings.logging

--- a/docs/source/chapt_flowsheet/tutorial/data.rst
+++ b/docs/source/chapt_flowsheet/tutorial/data.rst
@@ -24,7 +24,6 @@ an additional 100 times using a UQ ensemble (see :ref:`chapt_uq/index:Uncertaint
 #. Click **Flowsheet Data** in the toolbar on the left side of the Home
    window.
 
-.. _fig.data.table1:
 .. figure:: ../figs/data_table_1.svg
    :alt: Flowsheet Results Data Table, All Data
    :name: fig.data.table1
@@ -79,7 +78,6 @@ Sorting Data
 
 #. Click **Done** to save the filters and return to the results table.
 
-.. _fig.filter.1:
 .. figure:: ../figs/filter_1.svg
    :alt: Sort1 Data Filter
    :name: fig.filter.1
@@ -92,7 +90,6 @@ Sorting Data
     sorted in reverse alphabetical order by **result**. Some of the
     columns are hidden to make the relevant results easier to see.
 
-.. _fig.filter.1.result:
 .. figure:: ../figs/filter_1_result.svg
    :alt: Sort1 Data Filter Results
    :name: fig.filter.1.result
@@ -109,7 +106,6 @@ Sorting Data
 
 20. Click **Done**.
 
-.. _fig.filter.2:
 .. figure:: ../figs/filter_2.svg
    :alt: Sort2 Data Filter
    :name: fig.filter.2
@@ -122,7 +118,6 @@ Sorting Data
     sorted so all **Error** code zero results are first then sorted in
     reverse alphabetical order by **result**.
 
-.. _fig.filter.2.result:
 .. figure:: ../figs/filter_2_result.svg
    :alt: Sort2 Data Filter Result
    :name: fig.filter.2.result
@@ -157,7 +152,6 @@ field enter ``np.logical_and(c("err") == 0, c("set") == "Single_runs")``
 
 10. Click **Done**.
 
-.. _fig.filter.3:
 .. figure:: ../figs/filter_3.svg
    :alt: Filter1 Data Filter
    :name: fig.filter.3
@@ -169,7 +163,6 @@ field enter ``np.logical_and(c("err") == 0, c("set") == "Single_runs")``
 
 12. The result is displayed in the Figure below.
 
-.. _fig.filter.3.result:
 .. figure:: ../figs/filter_3_result.svg
    :alt: Filter1 Data Filter Result
    :name: fig.filter.3.result

--- a/docs/source/chapt_flowsheet/tutorial/data.rst
+++ b/docs/source/chapt_flowsheet/tutorial/data.rst
@@ -24,7 +24,7 @@ an additional 100 times using a UQ ensemble (see :ref:`chapt_uq/index:Uncertaint
 #. Click **Flowsheet Data** in the toolbar on the left side of the Home
    window.
 
-.. _fig.data.table1
+.. _fig.data.table1:
 .. figure:: ../figs/data_table_1.svg
    :alt: Flowsheet Results Data Table, All Data
    :name: fig.data.table1
@@ -79,7 +79,7 @@ Sorting Data
 
 #. Click **Done** to save the filters and return to the results table.
 
-.. _fig.filter.1
+.. _fig.filter.1:
 .. figure:: ../figs/filter_1.svg
    :alt: Sort1 Data Filter
    :name: fig.filter.1
@@ -92,7 +92,7 @@ Sorting Data
     sorted in reverse alphabetical order by **result**. Some of the
     columns are hidden to make the relevant results easier to see.
 
-.. _fig.filter.1.result
+.. _fig.filter.1.result:
 .. figure:: ../figs/filter_1_result.svg
    :alt: Sort1 Data Filter Results
    :name: fig.filter.1.result
@@ -109,7 +109,7 @@ Sorting Data
 
 20. Click **Done**.
 
-.. _fig.filter.2
+.. _fig.filter.2:
 .. figure:: ../figs/filter_2.svg
    :alt: Sort2 Data Filter
    :name: fig.filter.2
@@ -122,7 +122,7 @@ Sorting Data
     sorted so all **Error** code zero results are first then sorted in
     reverse alphabetical order by **result**.
 
-.. _fig.filter.2.result
+.. _fig.filter.2.result:
 .. figure:: ../figs/filter_2_result.svg
    :alt: Sort2 Data Filter Result
    :name: fig.filter.2.result
@@ -157,7 +157,7 @@ field enter ``np.logical_and(c("err") == 0, c("set") == "Single_runs")``
 
 10. Click **Done**.
 
-.. _fig.filter.3
+.. _fig.filter.3:
 .. figure:: ../figs/filter_3.svg
    :alt: Filter1 Data Filter
    :name: fig.filter.3
@@ -169,7 +169,7 @@ field enter ``np.logical_and(c("err") == 0, c("set") == "Single_runs")``
 
 12. The result is displayed in the Figure below.
 
-.. _fig.filter.3.result
+.. _fig.filter.3.result:
 .. figure:: ../figs/filter_3_result.svg
    :alt: Filter1 Data Filter Result
    :name: fig.filter.3.result

--- a/docs/source/chapt_flowsheet/tutorial/recycle.rst
+++ b/docs/source/chapt_flowsheet/tutorial/recycle.rst
@@ -34,7 +34,6 @@ two reactors in recycle loops. The flowsheet contains mixers, reactors,
 separators, and splitters. Each node uses a set of simple calculations
 in the node script section. The tear edges are shown in light blue.
 
-.. _fig.recycle.tut1:
 .. figure:: ../figs/recycle_tut1.svg
    :alt: Flowsheet with Recycle
    :name: fig.recycle.tut1
@@ -66,14 +65,12 @@ in the node script section. The tear edges are shown in light blue.
    :ref:`fig.recycle.tut2`. The tear solver settings
    are shown in Figure :ref:`fig.tear.settings`.
 
-.. _fig.recycle.tut2:
 .. figure:: ../figs/recycle_tut2.svg
    :alt: React_01 Node
    :name: fig.recycle.tut2
 
    React_01 Node
 
-.. _fig.tear.settings:
 .. figure:: ../figs/tear_solver_settings.svg
    :alt: Tear Solver Settings
    :name: fig.tear.settings
@@ -95,7 +92,6 @@ in the node script section. The tear edges are shown in light blue.
 
 8. Close the Edge Editor.
 
-.. _fig.recycle.tut3:
 .. figure:: ../figs/recycle_tut3.svg
    :alt: Edge Edit
    :name: fig.recycle.tut3

--- a/docs/source/chapt_flowsheet/tutorial/recycle.rst
+++ b/docs/source/chapt_flowsheet/tutorial/recycle.rst
@@ -34,7 +34,7 @@ two reactors in recycle loops. The flowsheet contains mixers, reactors,
 separators, and splitters. Each node uses a set of simple calculations
 in the node script section. The tear edges are shown in light blue.
 
-.. _fig.recycle.tut1
+.. _fig.recycle.tut1:
 .. figure:: ../figs/recycle_tut1.svg
    :alt: Flowsheet with Recycle
    :name: fig.recycle.tut1
@@ -66,14 +66,14 @@ in the node script section. The tear edges are shown in light blue.
    :ref:`fig.recycle.tut2`. The tear solver settings
    are shown in Figure :ref:`fig.tear.settings`.
 
-.. _fig.recycle.tut2
+.. _fig.recycle.tut2:
 .. figure:: ../figs/recycle_tut2.svg
    :alt: React_01 Node
    :name: fig.recycle.tut2
 
    React_01 Node
 
-.. _fig.tear.settings
+.. _fig.tear.settings:
 .. figure:: ../figs/tear_solver_settings.svg
    :alt: Tear Solver Settings
    :name: fig.tear.settings
@@ -95,7 +95,7 @@ in the node script section. The tear edges are shown in light blue.
 
 8. Close the Edge Editor.
 
-.. _fig.recycle.tut3
+.. _fig.recycle.tut3:
 .. figure:: ../figs/recycle_tut3.svg
    :alt: Edge Edit
    :name: fig.recycle.tut3

--- a/docs/source/chapt_flowsheet/tutorial/remote.rst
+++ b/docs/source/chapt_flowsheet/tutorial/remote.rst
@@ -39,7 +39,6 @@ remotely (see Figure :ref:`fig.remote.settings`).
 #. Click the **Turbine** tab; this displays the Turbine settings shown
    in Figure :ref:`fig.remote.settings`.
 
-.. _fig.remote.settings1:
 .. figure:: ../figs/settings_turbine_01.svg
    :alt: Run Method Settings
    :name: fig.remote.settings1
@@ -68,7 +67,6 @@ remotely (see Figure :ref:`fig.remote.settings`).
       to the **Turbine Configuration (remote)** field. Select the file
       created in Step 6e.
 
-.. _fig.remote.settings:
 .. figure:: ../figs/remoteSetting.svg
    :alt: Remote Turbine Settings
    :name: fig.remote.settings

--- a/docs/source/chapt_flowsheet/tutorial/remote.rst
+++ b/docs/source/chapt_flowsheet/tutorial/remote.rst
@@ -39,7 +39,7 @@ remotely (see Figure :ref:`fig.remote.settings`).
 #. Click the **Turbine** tab; this displays the Turbine settings shown
    in Figure :ref:`fig.remote.settings`.
 
-.. _fig.remote.settings1
+.. _fig.remote.settings1:
 .. figure:: ../figs/settings_turbine_01.svg
    :alt: Run Method Settings
    :name: fig.remote.settings1
@@ -68,7 +68,7 @@ remotely (see Figure :ref:`fig.remote.settings`).
       to the **Turbine Configuration (remote)** field. Select the file
       created in Step 6e.
 
-.. _fig.remote.settings
+.. _fig.remote.settings:
 .. figure:: ../figs/remoteSetting.svg
    :alt: Remote Turbine Settings
    :name: fig.remote.settings

--- a/docs/source/chapt_flowsheet/tutorial/sim_flowsheet.rst
+++ b/docs/source/chapt_flowsheet/tutorial/sim_flowsheet.rst
@@ -37,14 +37,14 @@ copy the example files to a convenient location.
    tab provides a record of the changes made each time the session is
    saved.
 
-.. _fig.tut.opt.session
+.. _fig.tut.opt.session:
 .. figure:: ../figs/session.svg
    :alt: Session Setup
    :name: fig.tut.opt.session
 
    Session Setup
 
-.. _fig.tut.opt.description
+.. _fig.tut.opt.description:
 .. figure:: ../figs/description.svg
    :alt: Session Description
    :name: fig.tut.opt.description
@@ -87,14 +87,14 @@ step is to upload the models to Turbine.
 11. | Repeat the upload process for the cost model. Name the model
     | BFB_v6_2_Cost.
 
-.. _fig.tut.opt.menu.upload
+.. _fig.tut.opt.menu.upload:
 .. figure:: ../figs/menu_upload.svg
    :alt: Open Upload to Turbine Dialog
    :name: fig.tut.opt.menu.upload
 
    Open Upload to Turbine Dialog
 
-.. _fig.tut.opt.upload
+.. _fig.tut.opt.upload:
 .. figure:: ../figs/upload.svg
    :alt: Upload to Turbine Dialog
    :name: fig.tut.opt.upload
@@ -102,7 +102,7 @@ step is to upload the models to Turbine.
    Upload to Turbine Dialog
 
 The next step is to create the flowsheet. Figure
-:ref:`fig.tut.opt.drawFlowsheet`illustrates
+:ref:`fig.tut.opt.drawFlowsheet` illustrates
 the steps to draw the flowsheet.
 
 12. Click **Flowsheet** at the top of the Home window.
@@ -122,7 +122,7 @@ the steps to draw the flowsheet.
     illustrated in Figure
     :ref:`fig.tut.opt.nodeEditor`.
 
-.. _fig.tut.opt.drawFlowsheet
+.. _fig.tut.opt.drawFlowsheet:
 .. figure:: ../figs/flowsheetDraw.svg
    :alt: Flowsheet Editor
    :name: fig.tut.opt.drawFlowsheet
@@ -148,7 +148,7 @@ simulation uploaded to Turbine. The Node Editor is illustrated in Figure
 22. Repeat the process for the cost node, assigning it the BFB_v6_2_cost
     simulation.
 
-.. _fig.tut.opt.nodeEditor
+.. _fig.tut.opt.nodeEditor:
 .. figure:: ../figs/nodeEditor.svg
    :alt: Node Editor
    :name: fig.tut.opt.nodeEditor
@@ -176,7 +176,7 @@ transferred from the BFB simulation to the cost simulation.
     **Auto** button should be used carefully. There should be 46
     connected variables.
 
-.. _fig.tut.opt.edgeEditor
+.. _fig.tut.opt.edgeEditor:
 .. figure:: ../figs/edgeEditor.svg
    :alt: Edge Editor
    :name: fig.tut.opt.edgeEditor

--- a/docs/source/chapt_flowsheet/tutorial/sim_flowsheet.rst
+++ b/docs/source/chapt_flowsheet/tutorial/sim_flowsheet.rst
@@ -37,14 +37,12 @@ copy the example files to a convenient location.
    tab provides a record of the changes made each time the session is
    saved.
 
-.. _fig.tut.opt.session:
 .. figure:: ../figs/session.svg
    :alt: Session Setup
    :name: fig.tut.opt.session
 
    Session Setup
 
-.. _fig.tut.opt.description:
 .. figure:: ../figs/description.svg
    :alt: Session Description
    :name: fig.tut.opt.description
@@ -87,14 +85,12 @@ step is to upload the models to Turbine.
 11. | Repeat the upload process for the cost model. Name the model
     | BFB_v6_2_Cost.
 
-.. _fig.tut.opt.menu.upload:
 .. figure:: ../figs/menu_upload.svg
    :alt: Open Upload to Turbine Dialog
    :name: fig.tut.opt.menu.upload
 
    Open Upload to Turbine Dialog
 
-.. _fig.tut.opt.upload:
 .. figure:: ../figs/upload.svg
    :alt: Upload to Turbine Dialog
    :name: fig.tut.opt.upload
@@ -122,7 +118,6 @@ the steps to draw the flowsheet.
     illustrated in Figure
     :ref:`fig.tut.opt.nodeEditor`.
 
-.. _fig.tut.opt.drawFlowsheet:
 .. figure:: ../figs/flowsheetDraw.svg
    :alt: Flowsheet Editor
    :name: fig.tut.opt.drawFlowsheet
@@ -148,7 +143,6 @@ simulation uploaded to Turbine. The Node Editor is illustrated in Figure
 22. Repeat the process for the cost node, assigning it the BFB_v6_2_cost
     simulation.
 
-.. _fig.tut.opt.nodeEditor:
 .. figure:: ../figs/nodeEditor.svg
    :alt: Node Editor
    :name: fig.tut.opt.nodeEditor
@@ -176,7 +170,6 @@ transferred from the BFB simulation to the cost simulation.
     **Auto** button should be used carefully. There should be 46
     connected variables.
 
-.. _fig.tut.opt.edgeEditor:
 .. figure:: ../figs/edgeEditor.svg
    :alt: Edge Editor
    :name: fig.tut.opt.edgeEditor

--- a/docs/source/chapt_flowsheet/tutorial/simple_flowsheet.rst
+++ b/docs/source/chapt_flowsheet/tutorial/simple_flowsheet.rst
@@ -14,7 +14,6 @@ provided.
 #. In the session form enter the **Session Name** as “Simple_Flow”
    (Figure :ref:`fig.session.name1`).
 
-.. _fig.session.name1:
 .. figure:: ../figs/session_name1.svg
    :alt: Setting the Session Name
    :name: fig.session.name1
@@ -31,7 +30,6 @@ provided.
       buttons above the **Description** tab box can be used to format
       the text.
 
-.. _fig.session.description1:
 .. figure:: ../figs/session_description1.svg
    :alt: Setting the Session Description
    :name: fig.session.description1
@@ -77,7 +75,6 @@ provided.
 
    h. Enter 4 for the value of x2.
 
-.. _fig.simple.flow1:
 .. figure:: ../figs/simple_flow_1.svg
    :alt: Flowsheet, Input Variables
    :name: fig.simple.flow1
@@ -96,7 +93,6 @@ provided.
 
    c. Enter z in the output **Name** dialog box.
 
-.. _fig.simple.flow2:
 .. figure:: ../figs/simple_flow_2.svg
    :alt: Flowsheet, Output Variables
    :name: fig.simple.flow2
@@ -130,7 +126,6 @@ The flowsheet should run successfully and the output value should be 2.
 Rerun the flowsheet with a negative value for x2, and observe the
 result. The simulation should report an error.
 
-.. _fig.simple.flow3:
 .. figure:: ../figs/simple_flow_3.svg
    :alt: Node Calculation
    :name: fig.simple.flow3
@@ -150,7 +145,6 @@ result. The simulation should report an error.
     #. The default file name is the session name. Change the file name
        and location if desired.
 
-.. _fig.simple.flow.save:
 .. figure:: ../figs/simple_flow_save.svg
    :alt: Save Session
    :name: fig.simple.flow.save

--- a/docs/source/chapt_flowsheet/tutorial/simple_flowsheet.rst
+++ b/docs/source/chapt_flowsheet/tutorial/simple_flowsheet.rst
@@ -14,7 +14,7 @@ provided.
 #. In the session form enter the **Session Name** as “Simple_Flow”
    (Figure :ref:`fig.session.name1`).
 
-.. _fig.session.name1
+.. _fig.session.name1:
 .. figure:: ../figs/session_name1.svg
    :alt: Setting the Session Name
    :name: fig.session.name1
@@ -31,7 +31,7 @@ provided.
       buttons above the **Description** tab box can be used to format
       the text.
 
-.. _fig.session.description1
+.. _fig.session.description1:
 .. figure:: ../figs/session_description1.svg
    :alt: Setting the Session Description
    :name: fig.session.description1
@@ -77,7 +77,7 @@ provided.
 
    h. Enter 4 for the value of x2.
 
-.. _fig.simple.flow1
+.. _fig.simple.flow1:
 .. figure:: ../figs/simple_flow_1.svg
    :alt: Flowsheet, Input Variables
    :name: fig.simple.flow1
@@ -96,7 +96,7 @@ provided.
 
    c. Enter z in the output **Name** dialog box.
 
-.. _fig.simple.flow2
+.. _fig.simple.flow2:
 .. figure:: ../figs/simple_flow_2.svg
    :alt: Flowsheet, Output Variables
    :name: fig.simple.flow2
@@ -130,7 +130,7 @@ The flowsheet should run successfully and the output value should be 2.
 Rerun the flowsheet with a negative value for x2, and observe the
 result. The simulation should report an error.
 
-.. _fig.simple.flow3
+.. _fig.simple.flow3:
 .. figure:: ../figs/simple_flow_3.svg
    :alt: Node Calculation
    :name: fig.simple.flow3
@@ -150,7 +150,7 @@ result. The simulation should report an error.
     #. The default file name is the session name. Change the file name
        and location if desired.
 
-.. _fig.simple.flow.save
+.. _fig.simple.flow.save:
 .. figure:: ../figs/simple_flow_save.svg
    :alt: Save Session
    :name: fig.simple.flow.save

--- a/docs/source/chapt_heat/reference.rst
+++ b/docs/source/chapt_heat/reference.rst
@@ -27,7 +27,7 @@ control the performance of heat integration. Output variables display
 heat integration results, which are used as final results or inputs for
 steam cycle calculations.
 
-.. _heat.int.inputs
+.. _heat.int.inputs:
 .. figure:: figs/heat_int_inputs.png
    :alt: Heat Integration Node Editor (Input Variables)
    :name: heat.int.inputs
@@ -85,7 +85,7 @@ The Heat Integration Node **Input Variables** are listed below:
    on their own projects. The variables **Life.Plant**, **No.Stream**,
    **Operation.Hours**, and **ROR** are used for the cost calculation.
 
-.. _heat.int.outputs
+.. _heat.int.outputs:
 .. figure:: figs/heat_int_outputs.png
    :alt: Heat Integration Node Editor (Output Variables)
    :name: heat.int.outputs
@@ -169,7 +169,7 @@ value assigned, except net power output and net efficiency without CCS.
 Output variables describe effects of CCS and heat integration to net
 power output and net efficiency.
 
-.. _steam.cycle.inputs
+.. _steam.cycle.inputs:
 .. figure:: figs/steam_cycle_inputs.png
    :alt: Steam Cycle Node Editor (Input Variables)
    :name: steam.cycle.inputs
@@ -218,7 +218,7 @@ The **Input Variables** of the Steam Cycle Node are described below:
    calculations. Both **Net.Efficiency** and **Net.Power** provide base
    case values for a power plant without CCS and heat integration.
 
-.. _steam.cycle.outputs
+.. _steam.cycle.outputs:
 .. figure:: figs/steam_cycle_outputs.png
    :alt: Steam Cycle Node Editor (Output Variables)
    :name: steam.cycle.outputs

--- a/docs/source/chapt_heat/reference.rst
+++ b/docs/source/chapt_heat/reference.rst
@@ -27,7 +27,6 @@ control the performance of heat integration. Output variables display
 heat integration results, which are used as final results or inputs for
 steam cycle calculations.
 
-.. _heat.int.inputs:
 .. figure:: figs/heat_int_inputs.png
    :alt: Heat Integration Node Editor (Input Variables)
    :name: heat.int.inputs
@@ -85,7 +84,6 @@ The Heat Integration Node **Input Variables** are listed below:
    on their own projects. The variables **Life.Plant**, **No.Stream**,
    **Operation.Hours**, and **ROR** are used for the cost calculation.
 
-.. _heat.int.outputs:
 .. figure:: figs/heat_int_outputs.png
    :alt: Heat Integration Node Editor (Output Variables)
    :name: heat.int.outputs
@@ -169,7 +167,6 @@ value assigned, except net power output and net efficiency without CCS.
 Output variables describe effects of CCS and heat integration to net
 power output and net efficiency.
 
-.. _steam.cycle.inputs:
 .. figure:: figs/steam_cycle_inputs.png
    :alt: Steam Cycle Node Editor (Input Variables)
    :name: steam.cycle.inputs
@@ -218,7 +215,6 @@ The **Input Variables** of the Steam Cycle Node are described below:
    calculations. Both **Net.Efficiency** and **Net.Power** provide base
    case values for a power plant without CCS and heat integration.
 
-.. _steam.cycle.outputs:
 .. figure:: figs/steam_cycle_outputs.png
    :alt: Steam Cycle Node Editor (Output Variables)
    :name: steam.cycle.outputs

--- a/docs/source/chapt_heat/tutorial.rst
+++ b/docs/source/chapt_heat/tutorial.rst
@@ -57,7 +57,6 @@ Start FOQUS. Start a new session. In the “Session Information” screen,
 under the **Metadata** tab, enter “BFB_CP_HI_SC” in the **Session Name**
 field (Figure :ref:`start.session`). Save the session.
 
-.. _start.session:
 .. figure:: ./figs/start_session.png
    :alt: Start a New Session
    :name: start.session
@@ -76,7 +75,6 @@ dialog, upload the BFB ACM model file (Figure
 for the BFB model is BFB_3ads_2rgn.json. Enter “BFB_3ads_2rgn” in the
 **Simulation Name** drop-down list.
 
-.. _upload model:
 .. figure:: figs/upload_model.png
    :alt: Upload Simulation Models
    :name: upload model
@@ -107,7 +105,6 @@ and compressor process. It is a user-specified Python calculation node
 and is described later. All edges should be the same directions as those
 in the figure.
 
-.. _flowsheet.heat.int:
 .. figure:: figs/flowsheet_heat_int.png
    :alt: Flowsheet of Heat Integration Example
    :name: flowsheet.heat.int
@@ -129,7 +126,6 @@ Edit Nodes
      description for heat integration tags is covered later. No other
      changes are required for the two nodes.
 
-.. _bfb.node.edit:
 .. figure:: figs/bfb_node_edit.png
    :alt: BFB Node Editor
    :name: bfb.node.edit
@@ -144,21 +140,18 @@ Edit Nodes
    dialog box, choose “None” in the **Type** drop-down list and leave
    the **Model** drop-down list blank.
 
-   .. _total.cons.inputs:
    .. figure:: figs/total_cons_inputs.png
       :alt: Total Consumption Node Editor (Input Variables)
       :name: total.cons.inputs
 
       Total Consumption Node Editor (Input Variables)
 
-   .. _total.cons.outputs:
    .. figure:: figs/total_cons_outputs.png
       :alt: Total Consumption Node Editor (Output Variables)
       :name: total.cons.outputs
 
       Total Consumption Node Editor (Output Variables)
 
-   .. _total.cons.python:
    .. figure:: figs/total_cons_python.png
       :alt: Total Consumption Node Editor (Python Codes)
       :name: total.cons.python
@@ -206,7 +199,6 @@ Edit Nodes
    Editor for the **Heat Integration Node** is shown in Figure
    :ref:`heat.int.node.edit`.
 
-.. _heat.int.node.edit:
 .. figure:: figs/heat_int_node_edit.png
    :alt: Heat Integration Node Editor
    :name: heat.int.node.edit
@@ -236,35 +228,30 @@ variables. The editor for Edge *0* (BFB :math:`\rightarrow` Compressor),
 :math:`\rightarrow` Heat Integration) and *2* (Compressor
 :math:`\rightarrow` Heat Integration) have no variable connections.
 
-.. _edge.0.edit:
 .. figure:: figs/edge_0_edit.png
    :alt: Editor for Edge 0
    :name: edge.0.edit
 
    Editor for Edge 0
 
-.. _edge.3.edit:
 .. figure:: figs/edge_3_edit.png
    :alt: Editor for Edge 3
    :name: edge.3.edit
 
    Editor for Edge 3
 
-.. _edge.4.edit:
 .. figure:: figs/edge_4_edit.png
    :alt: Editor for Edge 4
    :name: edge.4.edit
 
    Editor for Edge 4
 
-.. _edge.5.edit:
 .. figure:: figs/edge_5_edit.png
    :alt: Editor for Edge 5
    :name: edge.5.edit
 
    Editor for Edge 5
 
-.. _edge.6.edit:
 .. figure:: figs/edge_6_edit.png
    :alt: Editor for Edge 6
    :name: edge.6.edit
@@ -284,6 +271,7 @@ of heat source the variable is involved in. The detailed lists of tags
 are provided in Tables :ref:`tag.1`, :ref:`tag.2`,
 :ref:`tag.3`, and :ref:`tag.4`.
 
+.. _tag.1:
 .. table:: Tag 1: Block Name
 
    +-----------------------+-----------------------+-----------------------+
@@ -295,6 +283,7 @@ are provided in Tables :ref:`tag.1`, :ref:`tag.2`,
    |                       | associated with       |                       |
    +-----------------------+-----------------------+-----------------------+
 
+.. _tag.2:
 .. table:: Tag 2: Type of Port
 
    +---------------------+----------------------------------+----------+
@@ -311,6 +300,7 @@ are provided in Tables :ref:`tag.1`, :ref:`tag.2`,
    | “Blk_Var”           | Block variable (not in any port) |          |
    +---------------------+----------------------------------+----------+
 
+.. _tag.3:
 .. table:: Tag 3: Type of Variable
 
    +---------+-----------------------------+----------+
@@ -321,6 +311,7 @@ are provided in Tables :ref:`tag.1`, :ref:`tag.2`,
    | “Q”     | Heat duty or heat flow rate |          |
    +---------+-----------------------------+----------+
 
+.. _tag.4:
 .. table:: Tag 4: Type of Heat Source
 
    +-----------------------+-----------------------+-----------------------+
@@ -391,7 +382,6 @@ illustrated below.
 Take the variable “BFBadsB_Q” in the BFB model as an example (Figure
 :ref:`add.heat.int.tags`):
 
-.. _add.heat.int.tags:
 .. figure:: figs/add_heat_int_tags.png
    :alt: Procedures for Adding Heat Integration Tags
    :name: add.heat.int.tags
@@ -448,42 +438,36 @@ Compressor output variables are shown in Figures
 :ref:`heat.int.tags.comp.2`, and
 :ref:`heat.int.tags.comp.3`.
 
-.. _heat.int.tags.bfb.1:
 .. figure:: figs/heat_int_tags_bfb_1.png
    :alt: Heat Integration Tags for BFB Output Variables (1)
    :name: heat.int.tags.bfb.1
 
    Heat Integration Tags for BFB Output Variables (1)
 
-.. _heat.int.tags.bfb.2:
 .. figure:: figs/heat_int_tags_bfb_2.png
    :alt: Heat Integration Tags for BFB Output Variables (2)
    :name: heat.int.tags.bfb.2
 
    Heat Integration Tags for BFB Output Variables (2)
 
-.. _heat.int.tags.bfb.3:
 .. figure:: figs/heat_int_tags_bfb_3.png
    :alt: Heat Integration Tags for BFB Output Variables (3)
    :name: heat.int.tags.bfb.3
 
    Heat Integration Tags for BFB Output Variables (3)
 
-.. _heat.int.tags.comp.1:
 .. figure:: figs/heat_int_tags_comp_1.png
    :alt: Heat Integration Tags for Compressor Output Variables (1)
    :name: heat.int.tags.comp.1
 
    Heat Integration Tags for Compressor Output Variables (1)
 
-.. _heat.int.tags.comp.2:
 .. figure:: ./figs/heat_int_tags_comp_2.png
    :alt: Heat Integration Tags for Compressor Output Variables (2)
    :name: heat.int.tags.comp.2
 
    Heat Integration Tags for Compressor Output Variables (2)
 
-.. _heat.int.tags.comp.3:
 .. figure:: ./figs/heat_int_tags_comp_3.png
    :alt: Heat Integration Tags for Compressor Output Variables (3)
    :name: heat.int.tags.comp.3
@@ -521,14 +505,12 @@ cycle calculation results (Figure
 output and net efficiency with CCS and heat integration, as well as
 their changes compared to the base case.
 
-.. _heat.int.results:
 .. figure:: figs/heat_int_results.png
    :alt: Heat Integration Results (Heat Integration Node)
    :name: heat.int.results
 
    Heat Integration Results (Heat Integration Node)
 
-.. _steam.cycle.results:
 .. figure:: figs/steam_cycle_results.png
    :alt: Steam Cycle Calculation Results (Steam Cycle Node)
    :name: steam.cycle.results

--- a/docs/source/chapt_heat/tutorial.rst
+++ b/docs/source/chapt_heat/tutorial.rst
@@ -57,7 +57,7 @@ Start FOQUS. Start a new session. In the “Session Information” screen,
 under the **Metadata** tab, enter “BFB_CP_HI_SC” in the **Session Name**
 field (Figure :ref:`start.session`). Save the session.
 
-.. _start.session
+.. _start.session:
 .. figure:: ./figs/start_session.png
    :alt: Start a New Session
    :name: start.session
@@ -76,7 +76,7 @@ dialog, upload the BFB ACM model file (Figure
 for the BFB model is BFB_3ads_2rgn.json. Enter “BFB_3ads_2rgn” in the
 **Simulation Name** drop-down list.
 
-.. _upload model
+.. _upload model:
 .. figure:: figs/upload_model.png
    :alt: Upload Simulation Models
    :name: upload model
@@ -107,7 +107,7 @@ and compressor process. It is a user-specified Python calculation node
 and is described later. All edges should be the same directions as those
 in the figure.
 
-.. _flowsheet.heat.int
+.. _flowsheet.heat.int:
 .. figure:: figs/flowsheet_heat_int.png
    :alt: Flowsheet of Heat Integration Example
    :name: flowsheet.heat.int
@@ -129,7 +129,7 @@ Edit Nodes
      description for heat integration tags is covered later. No other
      changes are required for the two nodes.
 
-.. _bfb.node.edit
+.. _bfb.node.edit:
 .. figure:: figs/bfb_node_edit.png
    :alt: BFB Node Editor
    :name: bfb.node.edit
@@ -144,21 +144,21 @@ Edit Nodes
    dialog box, choose “None” in the **Type** drop-down list and leave
    the **Model** drop-down list blank.
 
-   .. _total.cons.inputs
+   .. _total.cons.inputs:
    .. figure:: figs/total_cons_inputs.png
       :alt: Total Consumption Node Editor (Input Variables)
       :name: total.cons.inputs
 
       Total Consumption Node Editor (Input Variables)
 
-   .. _total.cons.outputs
+   .. _total.cons.outputs:
    .. figure:: figs/total_cons_outputs.png
       :alt: Total Consumption Node Editor (Output Variables)
       :name: total.cons.outputs
 
       Total Consumption Node Editor (Output Variables)
 
-   .. _total.cons.python
+   .. _total.cons.python:
    .. figure:: figs/total_cons_python.png
       :alt: Total Consumption Node Editor (Python Codes)
       :name: total.cons.python
@@ -206,7 +206,7 @@ Edit Nodes
    Editor for the **Heat Integration Node** is shown in Figure
    :ref:`heat.int.node.edit`.
 
-.. _heat.int.node.edit
+.. _heat.int.node.edit:
 .. figure:: figs/heat_int_node_edit.png
    :alt: Heat Integration Node Editor
    :name: heat.int.node.edit
@@ -236,35 +236,35 @@ variables. The editor for Edge *0* (BFB :math:`\rightarrow` Compressor),
 :math:`\rightarrow` Heat Integration) and *2* (Compressor
 :math:`\rightarrow` Heat Integration) have no variable connections.
 
-.. _edge.0.edit
+.. _edge.0.edit:
 .. figure:: figs/edge_0_edit.png
    :alt: Editor for Edge 0
    :name: edge.0.edit
 
    Editor for Edge 0
 
-.. _edge.3.edit
+.. _edge.3.edit:
 .. figure:: figs/edge_3_edit.png
    :alt: Editor for Edge 3
    :name: edge.3.edit
 
    Editor for Edge 3
 
-.. _edge.4.edit
+.. _edge.4.edit:
 .. figure:: figs/edge_4_edit.png
    :alt: Editor for Edge 4
    :name: edge.4.edit
 
    Editor for Edge 4
 
-.. _edge.5.edit
+.. _edge.5.edit:
 .. figure:: figs/edge_5_edit.png
    :alt: Editor for Edge 5
    :name: edge.5.edit
 
    Editor for Edge 5
 
-.. _edge.6.edit
+.. _edge.6.edit:
 .. figure:: figs/edge_6_edit.png
    :alt: Editor for Edge 6
    :name: edge.6.edit
@@ -391,7 +391,7 @@ illustrated below.
 Take the variable “BFBadsB_Q” in the BFB model as an example (Figure
 :ref:`add.heat.int.tags`):
 
-.. _add.heat.int.tags
+.. _add.heat.int.tags:
 .. figure:: figs/add_heat_int_tags.png
    :alt: Procedures for Adding Heat Integration Tags
    :name: add.heat.int.tags
@@ -448,42 +448,42 @@ Compressor output variables are shown in Figures
 :ref:`heat.int.tags.comp.2`, and
 :ref:`heat.int.tags.comp.3`.
 
-.. _heat.int.tags.bfb.1
+.. _heat.int.tags.bfb.1:
 .. figure:: figs/heat_int_tags_bfb_1.png
    :alt: Heat Integration Tags for BFB Output Variables (1)
    :name: heat.int.tags.bfb.1
 
    Heat Integration Tags for BFB Output Variables (1)
 
-.. _heat.int.tags.bfb.2
+.. _heat.int.tags.bfb.2:
 .. figure:: figs/heat_int_tags_bfb_2.png
    :alt: Heat Integration Tags for BFB Output Variables (2)
    :name: heat.int.tags.bfb.2
 
    Heat Integration Tags for BFB Output Variables (2)
 
-.. _heat.int.tags.bfb.3
+.. _heat.int.tags.bfb.3:
 .. figure:: figs/heat_int_tags_bfb_3.png
    :alt: Heat Integration Tags for BFB Output Variables (3)
    :name: heat.int.tags.bfb.3
 
    Heat Integration Tags for BFB Output Variables (3)
 
-.. _heat.int.tags.comp.1
+.. _heat.int.tags.comp.1:
 .. figure:: figs/heat_int_tags_comp_1.png
    :alt: Heat Integration Tags for Compressor Output Variables (1)
    :name: heat.int.tags.comp.1
 
    Heat Integration Tags for Compressor Output Variables (1)
 
-.. _heat.int.tags.comp.2
+.. _heat.int.tags.comp.2:
 .. figure:: ./figs/heat_int_tags_comp_2.png
    :alt: Heat Integration Tags for Compressor Output Variables (2)
    :name: heat.int.tags.comp.2
 
    Heat Integration Tags for Compressor Output Variables (2)
 
-.. _heat.int.tags.comp.3
+.. _heat.int.tags.comp.3:
 .. figure:: ./figs/heat_int_tags_comp_3.png
    :alt: Heat Integration Tags for Compressor Output Variables (3)
    :name: heat.int.tags.comp.3
@@ -521,14 +521,14 @@ cycle calculation results (Figure
 output and net efficiency with CCS and heat integration, as well as
 their changes compared to the base case.
 
-.. _heat.int.results
+.. _heat.int.results:
 .. figure:: figs/heat_int_results.png
    :alt: Heat Integration Results (Heat Integration Node)
    :name: heat.int.results
 
    Heat Integration Results (Heat Integration Node)
 
-.. _steam.cycle.results
+.. _steam.cycle.results:
 .. figure:: figs/steam_cycle_results.png
    :alt: Steam Cycle Calculation Results (Steam Cycle Node)
    :name: steam.cycle.results

--- a/docs/source/chapt_opt/reference/optimization.rst
+++ b/docs/source/chapt_opt/reference/optimization.rst
@@ -44,7 +44,7 @@ value will be based on a single flowsheet evaluation. Figure
 :ref:`fig.opt.problem.variables` shows the
 **Variables** tab selection form.
 
-.. _fig.opt.problem.variables
+.. _fig.opt.problem.variables:
 .. figure:: ../figs/opt_problem_variables.svg
    :alt: Optimization Variable Selection
    :name: fig.opt.problem.variables
@@ -90,7 +90,7 @@ each objective function value will be based on a single simulation.
 Figure :ref:`fig.opt.problem.samples` shows
 the Samples table form.
 
-.. _fig.opt.problem.samples
+.. _fig.opt.problem.samples:
 .. figure:: ../figs/opt_problem_samples.svg
    :alt: Optimization Sample Table
    :name: fig.opt.problem.samples
@@ -137,7 +137,7 @@ Figure :ref:`fig.opt.problem.objective1`
 shows the form for entering the objective function and constraints as
 Python expressions.
 
-.. _fig.opt.problem.objective1
+.. _fig.opt.problem.objective1:
 .. figure:: ../figs/opt_problem_objective1.svg
    :alt: Optimization Simple Objective Function
    :name: fig.opt.problem.objective1
@@ -247,7 +247,7 @@ debugging, so they are not required. It is safe to return [0] and 0 for
 the constraint information regardless of whether a constraint penalty
 has been added to the objective.
 
-.. _fig.opt.problem.objective2
+.. _fig.opt.problem.objective2:
 .. figure:: ../figs/opt_problem_objective2.svg
    :alt: Custom Objective Function
    :name: fig.opt.problem.objective2
@@ -297,7 +297,7 @@ selection of the DFO method and setting of solver parameters. Figure
 :ref:`fig.opt.solver.form` illustrates the solver
 form.
 
-.. _fig.opt.solver.form
+.. _fig.opt.solver.form:
 .. figure:: ../figs/opt_solver_form.svg
    :alt: Optimization Solver Form
    :name: fig.opt.solver.form
@@ -324,7 +324,7 @@ The optimization monitor is displayed under the **Run** tab in the
 Figure :ref:`fig.opt.run.form`, is used to monitor
 the progress of the optimization as it runs.
 
-.. _fig.opt.run.form
+.. _fig.opt.run.form:
 .. figure:: ../figs/opt_run_form.svg
    :alt: Optimization Monitor Form
    :name: fig.opt.run.form

--- a/docs/source/chapt_opt/reference/optimization.rst
+++ b/docs/source/chapt_opt/reference/optimization.rst
@@ -44,7 +44,6 @@ value will be based on a single flowsheet evaluation. Figure
 :ref:`fig.opt.problem.variables` shows the
 **Variables** tab selection form.
 
-.. _fig.opt.problem.variables:
 .. figure:: ../figs/opt_problem_variables.svg
    :alt: Optimization Variable Selection
    :name: fig.opt.problem.variables
@@ -90,7 +89,6 @@ each objective function value will be based on a single simulation.
 Figure :ref:`fig.opt.problem.samples` shows
 the Samples table form.
 
-.. _fig.opt.problem.samples:
 .. figure:: ../figs/opt_problem_samples.svg
    :alt: Optimization Sample Table
    :name: fig.opt.problem.samples
@@ -137,7 +135,6 @@ Figure :ref:`fig.opt.problem.objective1`
 shows the form for entering the objective function and constraints as
 Python expressions.
 
-.. _fig.opt.problem.objective1:
 .. figure:: ../figs/opt_problem_objective1.svg
    :alt: Optimization Simple Objective Function
    :name: fig.opt.problem.objective1
@@ -247,7 +244,6 @@ debugging, so they are not required. It is safe to return [0] and 0 for
 the constraint information regardless of whether a constraint penalty
 has been added to the objective.
 
-.. _fig.opt.problem.objective2:
 .. figure:: ../figs/opt_problem_objective2.svg
    :alt: Custom Objective Function
    :name: fig.opt.problem.objective2
@@ -275,6 +271,8 @@ returned as a list with only one element. The last two return values are
 debugging information for constraints. In this case, the “zeros” are
 just place holders and have no real utility.
 
+.. _fig.opt.problem.objective2_code:
+
 ::
 
    def objfunc(x, f, fail):
@@ -284,8 +282,6 @@ just place holders and have no real utility.
            obj=sum([(f[i]['Test']['y'][0] - x[i]['Test']['ydata'][0])**2\
              for i in range(len(f))])
        return [obj], [0], 0
-
-[fig.opt.problem.objective2_code]
 
 .. _sec.opt.solver.options:
 
@@ -297,7 +293,6 @@ selection of the DFO method and setting of solver parameters. Figure
 :ref:`fig.opt.solver.form` illustrates the solver
 form.
 
-.. _fig.opt.solver.form:
 .. figure:: ../figs/opt_solver_form.svg
    :alt: Optimization Solver Form
    :name: fig.opt.solver.form
@@ -324,7 +319,6 @@ The optimization monitor is displayed under the **Run** tab in the
 Figure :ref:`fig.opt.run.form`, is used to monitor
 the progress of the optimization as it runs.
 
-.. _fig.opt.run.form:
 .. figure:: ../figs/opt_run_form.svg
    :alt: Optimization Monitor Form
    :name: fig.opt.run.form

--- a/docs/source/chapt_opt/tutorial/parameter_est.rst
+++ b/docs/source/chapt_opt/tutorial/parameter_est.rst
@@ -24,6 +24,7 @@ given in Table :ref:`table.pe.data`.
    \label{eq.pe.tut}
    y = ax^2 + bx + c
 
+.. _table.pe.data:
 .. table:: x-y Data
 
    +--------+---+---+---+----+----+
@@ -44,7 +45,6 @@ have the input variables: a, b, c, x, and ydata; and output variable y.
 
 #. Click the **Flowsheet** button in the top toolbar.
 
-.. _fig.pe.tut1:
 .. figure:: ../figs/par_est_tut1.svg
    :alt: Session Setup
    :name: fig.pe.tut1
@@ -87,7 +87,6 @@ have the input variables: a, b, c, x, and ydata; and output variable y.
 
    #. The **Value**, **Min**, and **Max** for ydata do not matter.
 
-.. _fig.pe.tut2:
 .. figure:: ../figs/par_est_tut2.svg
    :alt: Adding Node and Inputs
    :name: fig.pe.tut2
@@ -104,7 +103,6 @@ have the input variables: a, b, c, x, and ydata; and output variable y.
 
    #. Enter “y” for the variable name in the **Name** column.
 
-.. _fig.pe.tut3:
 .. figure:: ../figs/par_est_tut3.svg
    :alt: Adding Outputs
    :name: fig.pe.tut3
@@ -122,8 +120,6 @@ have the input variables: a, b, c, x, and ydata; and output variable y.
           f['y'] = x['a']*x['x']**2\
            + x['b']*x['x'] + x['c']
 
-
-.. _fig.pe.tut4:
 .. figure:: ../figs/par_est_tut4.svg
    :alt: Adding Node Calculation
    :name: fig.pe.tut4
@@ -156,7 +152,6 @@ evaluations that need to go into the calculation of the objective.
 16. Select “Sample” in the **Type** column drop-down lists for “model.x”
     and “model.ydata.”
 
-.. _fig.pe.tut5:
 .. figure:: ../figs/par_est_tut5.svg
    :alt: Optimization Variables
    :name: fig.pe.tut5
@@ -178,7 +173,6 @@ objective function calculation.
 20. For larger sample sets, **Generate Samples** has an option to load
     from a CSV file.
 
-.. _fig.pe.tut6:
 .. figure:: ../figs/par_est_tut6.svg
    :alt: Optimization Samples
    :name: fig.pe.tut6
@@ -213,7 +207,6 @@ optimization solver changes the a, b, and c to minimize the objective.
 
 26. No constraints are required.
 
-.. _fig.pe.tut7:
 .. figure:: ../figs/par_est_tut7.svg
    :alt: Objective Function
    :name: fig.pe.tut7
@@ -233,7 +226,6 @@ with the default values.
 29. Select “BOBYQA” under the Solver Options table in the **Settings**
     column drop-down list.
 
-.. _fig.pe.tut8:
 .. figure:: ../figs/par_est_tut8.svg
    :alt: Optimization Samples
    :name: fig.pe.tut8
@@ -254,7 +246,6 @@ with the default values.
 34. The **Objective Function Plot** shows the value of the objective
     function as the optimization progresses.
 
-.. _fig.pe.tut9:
 .. figure:: ../figs/par_est_tut9.svg
    :alt: Running Optimization
    :name: fig.pe.tut9
@@ -272,7 +263,6 @@ stored in the flowsheet results table.
     The approximate result should be a = 2, b = -3, and c = 1 (see
     Figure :ref:`fig.pe.tut10`).
 
-.. _fig.pe.tut10:
 .. figure:: ../figs/par_est_tut10.svg
    :alt: Flowsheet, Input Variables Results
    :name: fig.pe.tut10

--- a/docs/source/chapt_opt/tutorial/parameter_est.rst
+++ b/docs/source/chapt_opt/tutorial/parameter_est.rst
@@ -44,7 +44,7 @@ have the input variables: a, b, c, x, and ydata; and output variable y.
 
 #. Click the **Flowsheet** button in the top toolbar.
 
-.. _fig.pe.tut1
+.. _fig.pe.tut1:
 .. figure:: ../figs/par_est_tut1.svg
    :alt: Session Setup
    :name: fig.pe.tut1
@@ -87,7 +87,7 @@ have the input variables: a, b, c, x, and ydata; and output variable y.
 
    #. The **Value**, **Min**, and **Max** for ydata do not matter.
 
-.. _fig.pe.tut2
+.. _fig.pe.tut2:
 .. figure:: ../figs/par_est_tut2.svg
    :alt: Adding Node and Inputs
    :name: fig.pe.tut2
@@ -104,7 +104,7 @@ have the input variables: a, b, c, x, and ydata; and output variable y.
 
    #. Enter “y” for the variable name in the **Name** column.
 
-.. _fig.pe.tut3
+.. _fig.pe.tut3:
 .. figure:: ../figs/par_est_tut3.svg
    :alt: Adding Outputs
    :name: fig.pe.tut3
@@ -123,7 +123,7 @@ have the input variables: a, b, c, x, and ydata; and output variable y.
            + x['b']*x['x'] + x['c']
 
 
-.. _fig.pe.tut4
+.. _fig.pe.tut4:
 .. figure:: ../figs/par_est_tut4.svg
    :alt: Adding Node Calculation
    :name: fig.pe.tut4
@@ -156,7 +156,7 @@ evaluations that need to go into the calculation of the objective.
 16. Select “Sample” in the **Type** column drop-down lists for “model.x”
     and “model.ydata.”
 
-.. _fig.pe.tut5
+.. _fig.pe.tut5:
 .. figure:: ../figs/par_est_tut5.svg
    :alt: Optimization Variables
    :name: fig.pe.tut5
@@ -178,7 +178,7 @@ objective function calculation.
 20. For larger sample sets, **Generate Samples** has an option to load
     from a CSV file.
 
-.. _fig.pe.tut6
+.. _fig.pe.tut6:
 .. figure:: ../figs/par_est_tut6.svg
    :alt: Optimization Samples
    :name: fig.pe.tut6
@@ -213,7 +213,7 @@ optimization solver changes the a, b, and c to minimize the objective.
 
 26. No constraints are required.
 
-.. _fig.pe.tut7
+.. _fig.pe.tut7:
 .. figure:: ../figs/par_est_tut7.svg
    :alt: Objective Function
    :name: fig.pe.tut7
@@ -233,7 +233,7 @@ with the default values.
 29. Select “BOBYQA” under the Solver Options table in the **Settings**
     column drop-down list.
 
-.. _fig.pe.tut8
+.. _fig.pe.tut8:
 .. figure:: ../figs/par_est_tut8.svg
    :alt: Optimization Samples
    :name: fig.pe.tut8
@@ -254,7 +254,7 @@ with the default values.
 34. The **Objective Function Plot** shows the value of the objective
     function as the optimization progresses.
 
-.. _fig.pe.tut9
+.. _fig.pe.tut9:
 .. figure:: ../figs/par_est_tut9.svg
    :alt: Running Optimization
    :name: fig.pe.tut9
@@ -272,7 +272,7 @@ stored in the flowsheet results table.
     The approximate result should be a = 2, b = -3, and c = 1 (see
     Figure :ref:`fig.pe.tut10`).
 
-.. _fig.pe.tut10
+.. _fig.pe.tut10:
 .. figure:: ../figs/par_est_tut10.svg
    :alt: Flowsheet, Input Variables Results
    :name: fig.pe.tut10

--- a/docs/source/chapt_opt/tutorial/simple.rst
+++ b/docs/source/chapt_opt/tutorial/simple.rst
@@ -39,7 +39,7 @@ constraints and (4) select and configure the solver.
    **Value** column specifies the initial point. For this example the
    defaults are acceptable.
 
-.. _tut.opt.problem.vars
+.. _tut.opt.problem.vars:
 .. figure:: ../figs/optProblemVar.svg
    :alt: Optimization Problem Variables
    :name: tut.opt.problem.vars
@@ -55,7 +55,7 @@ step is to define the objective function and constraints using the form
 under the **Objective/Constraints** tab as shown in Figure
 :ref:`tut.opt.problem.obj`.
 
-.. _tut.opt.problem.obj
+.. _tut.opt.problem.obj:
 .. figure:: ../figs/optProblemObj.svg
    :alt: Optimization Problem Objective
    :name: tut.opt.problem.obj
@@ -106,7 +106,7 @@ The last step before running the optimization is to select and configure
 the solver. The solver configuration form is shown in Figure
 :ref:`tut.opt.solver`.
 
-.. _tut.opt.solver
+.. _tut.opt.solver:
 .. figure:: ../figs/optSolver.svg
    :alt: Optimization Solver Setup
    :name: tut.opt.solver
@@ -126,7 +126,7 @@ Running Optimization
 The optimization run form is shown in Figure
 :ref:`tut.opt.run`.
 
-.. _tut.opt.run
+.. _tut.opt.run:
 .. figure:: ../figs/optRun.svg
    :alt: Optimization Monitor
    :name: tut.opt.run

--- a/docs/source/chapt_opt/tutorial/simple.rst
+++ b/docs/source/chapt_opt/tutorial/simple.rst
@@ -39,7 +39,6 @@ constraints and (4) select and configure the solver.
    **Value** column specifies the initial point. For this example the
    defaults are acceptable.
 
-.. _tut.opt.problem.vars:
 .. figure:: ../figs/optProblemVar.svg
    :alt: Optimization Problem Variables
    :name: tut.opt.problem.vars
@@ -55,7 +54,6 @@ step is to define the objective function and constraints using the form
 under the **Objective/Constraints** tab as shown in Figure
 :ref:`tut.opt.problem.obj`.
 
-.. _tut.opt.problem.obj:
 .. figure:: ../figs/optProblemObj.svg
    :alt: Optimization Problem Objective
    :name: tut.opt.problem.obj
@@ -106,7 +104,6 @@ The last step before running the optimization is to select and configure
 the solver. The solver configuration form is shown in Figure
 :ref:`tut.opt.solver`.
 
-.. _tut.opt.solver:
 .. figure:: ../figs/optSolver.svg
    :alt: Optimization Solver Setup
    :name: tut.opt.solver
@@ -126,7 +123,6 @@ Running Optimization
 The optimization run form is shown in Figure
 :ref:`tut.opt.run`.
 
-.. _tut.opt.run:
 .. figure:: ../figs/optRun.svg
    :alt: Optimization Monitor
    :name: tut.opt.run

--- a/docs/source/chapt_sdoe/index.rst
+++ b/docs/source/chapt_sdoe/index.rst
@@ -64,7 +64,7 @@ Using the SDoE Module - The Basics
 
 In this section, we descibe the basic steps in for creating a design with this module. When you first click on the  **SDOE** button from the main FOQUS homepage, a first window appears. To create a design, the progression of steps takes you through the **Ensemble Selection** box (top left), then a transition triggered by the **Confirm** button to the **Ensemble Aggregation** box, and finally there are optional changes that can be made in the box at the bottom of the window. The final step in this window is to click on **Create Design**. 
 
-.. _fig.sdoe_home
+.. _fig.sdoe_home:
 .. figure:: figs/1_home.png
    :alt: Home Screen
    :name: fig.sdoe_home
@@ -80,14 +80,14 @@ We now consider some details for each of these steps:
 
 3. Click on the **View** button to open the **Preview Inputs** pop-up widow, to see the list of columns contained in each file. The left hand side displays the first few rows of input combinations from the file. Select the columns that you wish to see graphically in the right hand box , and then click on **Plot SDOE** to see a scatterplot matrix of the data. 
 
-.. _fig.2_preview_inputs
+.. _fig.2_preview_inputs:
 .. figure:: figs/2_preview_inputs.png
    :alt: SDOE preview of inputs
    :name: fig.2_preview_inputs
    
    SDOE preview of inputs
 
-.. _fig.3_scatterplot_inputs
+.. _fig.3_scatterplot_inputs:
 .. figure:: figs/3_scatterplot_inputs.png
    :alt: SDOE plot of inputs
    :name: fig.3_scatterplot_inputs
@@ -102,7 +102,7 @@ The plot shows histograms of each of the inputs on the diagonals to provide a vi
 
 There are options to view the aggregated files for both the candidate and history files, with a similar interface as was shown in step 3. In addition, a single plot of the combined candidate and history files can be viewed, by (ADD DETAILS WHEN AVAILABLE). In this plot the (BLACK) points represent the candidate locations, while the (RED) points represent already collected data from the history file.
 
-.. _fig.4_scatterplot_aggregated
+.. _fig.4_scatterplot_aggregated:
 .. figure:: figs/4_scatterplot_aggregated.png
    :alt: SDOE plot of aggregated inputs
    :name: fig.4_scatterplot_aggregated
@@ -111,7 +111,7 @@ There are options to view the aggregated files for both the candidate and histor
    
 6. Once the data have been verified as the desired set to be used for the design construction, then click on the **Create Design** button at the bottom right corner of the **Ensemble Aggregation** window. This opens the second SDOE window, which allows for specific design choices to be made.
 
-.. _fig.5_SDOE_page2
+.. _fig.5_SDOE_page2:
 .. figure:: figs/5_SDOE_page2.png
    :alt: SDOE second window
    :name: fig.5_SDOE_page2
@@ -144,12 +144,12 @@ Example 1: 8-run 2-D design
 
 For this first example, the goal is to construct a simple space-filling design with 8 runs in a 2-dimensional space using the example files provided with FOQUS. 
 
-1. From the FOQUS main screen, click the **SDOE** button. On the top left side, select **Load from File**, and select the candidate.csv file from examples folder. This identifies the possible input combinations from which the design will be constructed. The more possible candidates that can be provided to the search algorithm used to construct the design, the better the design might be for the specified criterion. :ref:`fig.sdoe_home`.
+1. From the FOQUS main screen, click the **SDOE** button. On the top left side, select **Load from File**, and select the candidate.csv file from examples folder. This identifies the possible input combinations from which the design will be constructed. The more possible candidates that can be provided to the search algorithm used to construct the design, the better the design might be for the specified criterion. :ref:`fig.sdoe_home_2`.
 
-.. _fig.sdoe_home
+.. _fig.sdoe_home_2:
 .. figure:: figs/1_home.png
    :alt: Home Screen
-   :name: fig.sdoe_home
+   :name: fig.sdoe_home_2
    
    Home Screen
    

--- a/docs/source/chapt_sdoe/index.rst
+++ b/docs/source/chapt_sdoe/index.rst
@@ -64,7 +64,6 @@ Using the SDoE Module - The Basics
 
 In this section, we descibe the basic steps in for creating a design with this module. When you first click on the  **SDOE** button from the main FOQUS homepage, a first window appears. To create a design, the progression of steps takes you through the **Ensemble Selection** box (top left), then a transition triggered by the **Confirm** button to the **Ensemble Aggregation** box, and finally there are optional changes that can be made in the box at the bottom of the window. The final step in this window is to click on **Create Design**. 
 
-.. _fig.sdoe_home:
 .. figure:: figs/1_home.png
    :alt: Home Screen
    :name: fig.sdoe_home
@@ -80,14 +79,12 @@ We now consider some details for each of these steps:
 
 3. Click on the **View** button to open the **Preview Inputs** pop-up widow, to see the list of columns contained in each file. The left hand side displays the first few rows of input combinations from the file. Select the columns that you wish to see graphically in the right hand box , and then click on **Plot SDOE** to see a scatterplot matrix of the data. 
 
-.. _fig.2_preview_inputs:
 .. figure:: figs/2_preview_inputs.png
    :alt: SDOE preview of inputs
    :name: fig.2_preview_inputs
    
    SDOE preview of inputs
 
-.. _fig.3_scatterplot_inputs:
 .. figure:: figs/3_scatterplot_inputs.png
    :alt: SDOE plot of inputs
    :name: fig.3_scatterplot_inputs
@@ -102,7 +99,6 @@ The plot shows histograms of each of the inputs on the diagonals to provide a vi
 
 There are options to view the aggregated files for both the candidate and history files, with a similar interface as was shown in step 3. In addition, a single plot of the combined candidate and history files can be viewed, by (ADD DETAILS WHEN AVAILABLE). In this plot the (BLACK) points represent the candidate locations, while the (RED) points represent already collected data from the history file.
 
-.. _fig.4_scatterplot_aggregated:
 .. figure:: figs/4_scatterplot_aggregated.png
    :alt: SDOE plot of aggregated inputs
    :name: fig.4_scatterplot_aggregated
@@ -111,7 +107,6 @@ There are options to view the aggregated files for both the candidate and histor
    
 6. Once the data have been verified as the desired set to be used for the design construction, then click on the **Create Design** button at the bottom right corner of the **Ensemble Aggregation** window. This opens the second SDOE window, which allows for specific design choices to be made.
 
-.. _fig.5_SDOE_page2:
 .. figure:: figs/5_SDOE_page2.png
    :alt: SDOE second window
    :name: fig.5_SDOE_page2
@@ -146,7 +141,6 @@ For this first example, the goal is to construct a simple space-filling design w
 
 1. From the FOQUS main screen, click the **SDOE** button. On the top left side, select **Load from File**, and select the candidate.csv file from examples folder. This identifies the possible input combinations from which the design will be constructed. The more possible candidates that can be provided to the search algorithm used to construct the design, the better the design might be for the specified criterion. :ref:`fig.sdoe_home_2`.
 
-.. _fig.sdoe_home_2:
 .. figure:: figs/1_home.png
    :alt: Home Screen
    :name: fig.sdoe_home_2

--- a/docs/source/chapt_sinter/tutorial/acm.rst
+++ b/docs/source/chapt_sinter/tutorial/acm.rst
@@ -13,7 +13,7 @@ Aspen Custom Modeler Configuration
    click the splash screen to proceed, or wait ten seconds for it to
    close automatically.
 
-   .. _fig.sinter.acm.splash
+   .. _fig.sinter.acm.splash:
    .. figure:: ../figs/ap/01_Splash_Screen.png
       :alt: SinterConfigGUI Splash Screen
       :name: fig.sinter.acm.splash
@@ -34,7 +34,7 @@ Aspen Custom Modeler Configuration
    | Note: Opening the simulation may take a few minutes depending on
      how quickly Aspen Custom Modeler can be opened.
 
-   .. _fig.sinter.acm.openpage
+   .. _fig.sinter.acm.openpage:
    .. figure:: ../figs/ap/02_FileOpenScreen.png
       :alt: SinterConfigGUI Open Simulation Window
       :name: fig.sinter.acm.openpage
@@ -54,7 +54,7 @@ Aspen Custom Modeler Configuration
    location, since it automatically overwrites whatever file name
    currently exists.
 
-   .. _fig.sinter.acm.savename
+   .. _fig.sinter.acm.savename:
    .. figure:: ../figs/acm/03_MetaDataSave.png
       :alt: SinterConfigGUI Simulation Meta-Data Page Save Name Text Box
       :name: fig.sinter.acm.savename
@@ -64,7 +64,7 @@ Aspen Custom Modeler Configuration
 #. Continue to complete the remaining fields and then click **Next**
    (Figure :ref:`fig.sinter.acm.metadata`).
 
-   .. _fig.sinter.acm.metadata
+   .. _fig.sinter.acm.metadata:
    .. figure:: ../figs/acm/04_MetaDataFilled.png
       :name: fig.sinter.acm.metadata
 
@@ -86,7 +86,7 @@ Aspen Custom Modeler Configuration
    the same as Variable Find on the Tools menu in Aspen Custom Modeler.
    Please refer to the ACM documentation for details on search patterns.
 
-   .. _fig.sinter.acm.variableempty
+   .. _fig.sinter.acm.variableempty:
    .. figure:: ../figs/acm/05_VariablesEmpty.png
       :alt: SinterConfigGUI Variable Configuration Page before Input
       :name: fig.sinter.acm.variableempty
@@ -98,7 +98,7 @@ Aspen Custom Modeler Configuration
    :ref:`fig.sinter.acm.variableprogress`).
    Sometimes large searches take a while.
 
-   .. _fig.sinter.acm.variableprogress
+   .. _fig.sinter.acm.variableprogress:
    .. figure:: ../figs/acm/06_Search.png
       :alt: Search in Progress Bar Page
       :name: fig.sinter.acm.variableprogress
@@ -108,7 +108,7 @@ Aspen Custom Modeler Configuration
 #. First, select the “BFBadsT.A1” scalar variable in the **Selected
    Path** field (Figure :ref:`fig.sinter.acm.variableselected`).
 
-   .. _fig.sinter.acm.variableselected
+   .. _fig.sinter.acm.variableselected:
    .. figure:: ../figs/acm/07_VariablesSelected.png
       :name: fig.sinter.acm.variableselected
 
@@ -119,7 +119,7 @@ Aspen Custom Modeler Configuration
    (Figure :ref:`fig.sinter.acm.variablepreview`).
    Here, the user can verify the variable choices.
 
-   .. _fig.sinter.acm.variablepreview
+   .. _fig.sinter.acm.variablepreview:
    .. figure:: ../figs/acm/08_VariablePreview.png
       :name: fig.sinter.acm.variablepreview
 
@@ -129,7 +129,7 @@ Aspen Custom Modeler Configuration
    Input**. Information displays in the **Selected Input Variables**
    section (Figure :ref:`fig.sinter.acm.variableinput`).
 
-   .. _fig.sinter.acm.variableinput
+   .. _fig.sinter.acm.variableinput:
    .. figure:: ../figs/acm/09_VariablesInput.png
       :name: fig.sinter.acm.variableinput
 
@@ -139,7 +139,7 @@ Aspen Custom Modeler Configuration
    descriptive (e.g., “WaterA”). Set **Name**, **Description** and
    **Min/Max** as shown in Figure :ref:`fig.sinter.acm.variablename`.
 
-   .. _fig.sinter.acm.variablename
+   .. _fig.sinter.acm.variablename:
    .. figure:: ../figs/acm/10_VariablesInput2.png
       :name: fig.sinter.acm.variablename
 
@@ -154,7 +154,7 @@ Aspen Custom Modeler Configuration
    name is selected (“BFBadsT.db.Value”), the entire vector is
    displayed. Select the whole vector and click **Preview**.
 
-   .. _fig.sinter.acm.vectorpreview
+   .. _fig.sinter.acm.vectorpreview:
    .. figure:: ../figs/acm/11_VariablesArray1.png
       :alt: SinterConfigGUI Variable Configuration Page Vector Preview
       :name: fig.sinter.acm.vectorpreview
@@ -165,7 +165,7 @@ Aspen Custom Modeler Configuration
    Notice that this variable has a unit “m” (Figure 
    :ref:`fig.sinter.acm.vectoroutput`).
 
-   .. _fig.sinter.acm.vectoroutput
+   .. _fig.sinter.acm.vectoroutput:
    .. figure:: ../figs/acm/12_VariablesOutput.png
       :alt: SinterConfigGUI Variable Configuration Page Vector As Output
       :name: fig.sinter.acm.vectoroutput
@@ -178,7 +178,7 @@ Aspen Custom Modeler Configuration
    bubble diameter in mm (Figure :ref:`fig.sinter.acm.vectorunits`).
    Internal to the simulation, the unit remains “m.”
 
-   .. _fig.sinter.acm.vectorunits
+   .. _fig.sinter.acm.vectorunits:
    .. figure:: ../figs/acm/13_VariablesUnits.png
       :name: fig.sinter.acm.vectorunits
 
@@ -189,7 +189,7 @@ Aspen Custom Modeler Configuration
    To remove item that was just added, select it and click **Remove
    Variable**.
 
-   .. _fig.sinter.acm.vectorremoval
+   .. _fig.sinter.acm.vectorremoval:
    .. figure:: ../figs/acm/14_VariablesInput2.png
       :alt: SinterConfigGUI Variable Configuration Page Removal Demo
       :name: fig.sinter.acm.vectorremoval
@@ -203,7 +203,7 @@ Aspen Custom Modeler Configuration
    automatically. To change the **Min/Max** values, the user must edit
    the JSON file in a text editor.
 
-   .. _fig.sinter.acm.vectorreadd
+   .. _fig.sinter.acm.vectorreadd:
    .. figure:: ../figs/acm/15_VariablesInput4.png
       :alt: SinterConfigGUI Variable Configuration Page Read Input
       :name: fig.sinter.acm.vectorreadd
@@ -217,7 +217,7 @@ Aspen Custom Modeler Configuration
    modified in the window. In this case there is no need to change the
    values.
 
-   .. _fig.sinter.acm.vectorinput
+   .. _fig.sinter.acm.vectorinput:
    .. figure:: ../figs/acm/16_VectorInput.png
       :alt: SinterConfigGUI Vector Default Initialization Input Page
       :name: fig.sinter.acm.vectorinput

--- a/docs/source/chapt_sinter/tutorial/acm.rst
+++ b/docs/source/chapt_sinter/tutorial/acm.rst
@@ -13,7 +13,6 @@ Aspen Custom Modeler Configuration
    click the splash screen to proceed, or wait ten seconds for it to
    close automatically.
 
-   .. _fig.sinter.acm.splash:
    .. figure:: ../figs/ap/01_Splash_Screen.png
       :alt: SinterConfigGUI Splash Screen
       :name: fig.sinter.acm.splash
@@ -34,7 +33,6 @@ Aspen Custom Modeler Configuration
    | Note: Opening the simulation may take a few minutes depending on
      how quickly Aspen Custom Modeler can be opened.
 
-   .. _fig.sinter.acm.openpage:
    .. figure:: ../figs/ap/02_FileOpenScreen.png
       :alt: SinterConfigGUI Open Simulation Window
       :name: fig.sinter.acm.openpage
@@ -54,7 +52,6 @@ Aspen Custom Modeler Configuration
    location, since it automatically overwrites whatever file name
    currently exists.
 
-   .. _fig.sinter.acm.savename:
    .. figure:: ../figs/acm/03_MetaDataSave.png
       :alt: SinterConfigGUI Simulation Meta-Data Page Save Name Text Box
       :name: fig.sinter.acm.savename
@@ -64,7 +61,6 @@ Aspen Custom Modeler Configuration
 #. Continue to complete the remaining fields and then click **Next**
    (Figure :ref:`fig.sinter.acm.metadata`).
 
-   .. _fig.sinter.acm.metadata:
    .. figure:: ../figs/acm/04_MetaDataFilled.png
       :name: fig.sinter.acm.metadata
 
@@ -86,7 +82,6 @@ Aspen Custom Modeler Configuration
    the same as Variable Find on the Tools menu in Aspen Custom Modeler.
    Please refer to the ACM documentation for details on search patterns.
 
-   .. _fig.sinter.acm.variableempty:
    .. figure:: ../figs/acm/05_VariablesEmpty.png
       :alt: SinterConfigGUI Variable Configuration Page before Input
       :name: fig.sinter.acm.variableempty
@@ -98,7 +93,6 @@ Aspen Custom Modeler Configuration
    :ref:`fig.sinter.acm.variableprogress`).
    Sometimes large searches take a while.
 
-   .. _fig.sinter.acm.variableprogress:
    .. figure:: ../figs/acm/06_Search.png
       :alt: Search in Progress Bar Page
       :name: fig.sinter.acm.variableprogress
@@ -108,7 +102,6 @@ Aspen Custom Modeler Configuration
 #. First, select the “BFBadsT.A1” scalar variable in the **Selected
    Path** field (Figure :ref:`fig.sinter.acm.variableselected`).
 
-   .. _fig.sinter.acm.variableselected:
    .. figure:: ../figs/acm/07_VariablesSelected.png
       :name: fig.sinter.acm.variableselected
 
@@ -119,7 +112,6 @@ Aspen Custom Modeler Configuration
    (Figure :ref:`fig.sinter.acm.variablepreview`).
    Here, the user can verify the variable choices.
 
-   .. _fig.sinter.acm.variablepreview:
    .. figure:: ../figs/acm/08_VariablePreview.png
       :name: fig.sinter.acm.variablepreview
 
@@ -129,7 +121,6 @@ Aspen Custom Modeler Configuration
    Input**. Information displays in the **Selected Input Variables**
    section (Figure :ref:`fig.sinter.acm.variableinput`).
 
-   .. _fig.sinter.acm.variableinput:
    .. figure:: ../figs/acm/09_VariablesInput.png
       :name: fig.sinter.acm.variableinput
 
@@ -139,7 +130,6 @@ Aspen Custom Modeler Configuration
    descriptive (e.g., “WaterA”). Set **Name**, **Description** and
    **Min/Max** as shown in Figure :ref:`fig.sinter.acm.variablename`.
 
-   .. _fig.sinter.acm.variablename:
    .. figure:: ../figs/acm/10_VariablesInput2.png
       :name: fig.sinter.acm.variablename
 
@@ -154,7 +144,6 @@ Aspen Custom Modeler Configuration
    name is selected (“BFBadsT.db.Value”), the entire vector is
    displayed. Select the whole vector and click **Preview**.
 
-   .. _fig.sinter.acm.vectorpreview:
    .. figure:: ../figs/acm/11_VariablesArray1.png
       :alt: SinterConfigGUI Variable Configuration Page Vector Preview
       :name: fig.sinter.acm.vectorpreview
@@ -165,7 +154,6 @@ Aspen Custom Modeler Configuration
    Notice that this variable has a unit “m” (Figure 
    :ref:`fig.sinter.acm.vectoroutput`).
 
-   .. _fig.sinter.acm.vectoroutput:
    .. figure:: ../figs/acm/12_VariablesOutput.png
       :alt: SinterConfigGUI Variable Configuration Page Vector As Output
       :name: fig.sinter.acm.vectoroutput
@@ -178,7 +166,6 @@ Aspen Custom Modeler Configuration
    bubble diameter in mm (Figure :ref:`fig.sinter.acm.vectorunits`).
    Internal to the simulation, the unit remains “m.”
 
-   .. _fig.sinter.acm.vectorunits:
    .. figure:: ../figs/acm/13_VariablesUnits.png
       :name: fig.sinter.acm.vectorunits
 
@@ -189,7 +176,6 @@ Aspen Custom Modeler Configuration
    To remove item that was just added, select it and click **Remove
    Variable**.
 
-   .. _fig.sinter.acm.vectorremoval:
    .. figure:: ../figs/acm/14_VariablesInput2.png
       :alt: SinterConfigGUI Variable Configuration Page Removal Demo
       :name: fig.sinter.acm.vectorremoval
@@ -203,7 +189,6 @@ Aspen Custom Modeler Configuration
    automatically. To change the **Min/Max** values, the user must edit
    the JSON file in a text editor.
 
-   .. _fig.sinter.acm.vectorreadd:
    .. figure:: ../figs/acm/15_VariablesInput4.png
       :alt: SinterConfigGUI Variable Configuration Page Read Input
       :name: fig.sinter.acm.vectorreadd
@@ -217,7 +202,6 @@ Aspen Custom Modeler Configuration
    modified in the window. In this case there is no need to change the
    values.
 
-   .. _fig.sinter.acm.vectorinput:
    .. figure:: ../figs/acm/16_VectorInput.png
       :alt: SinterConfigGUI Vector Default Initialization Input Page
       :name: fig.sinter.acm.vectorinput

--- a/docs/source/chapt_sinter/tutorial/ap.rst
+++ b/docs/source/chapt_sinter/tutorial/ap.rst
@@ -9,7 +9,6 @@ Aspen Plus Configuration
    Open the Aspen Plus file and enter the metadata as shown in Figure
    :ref:`fig.sinter.ap.metadata`.
 
-   .. _fig.sinter.ap.metadata:
    .. figure:: ../figs/ap/04_MetaDataFilled.png
       :alt: SinterConfigGUI Simulation Meta-Data with Data Completed
       :name: fig.sinter.ap.metadata
@@ -24,7 +23,6 @@ Aspen Plus Configuration
    Aspen Plus Tools :math:`\rightarrow` Variable Explorer.
    Unfortunately, searching is not possible.
 
-   .. _fig.sinter.ap.variableempty:
    .. figure:: ../figs/ap/05_VariablesEmpty.png
       :alt: SinterConfigGUI Variable Configuration Page Empty Variables
       :name: fig.sinter.ap.variableempty
@@ -34,7 +32,6 @@ Aspen Plus Configuration
 #. **Variable Tree** nodes can be expanded for searching (Figure
    :ref:`fig.sinter.ap.expandtree`).
 
-   .. _fig.sinter.ap.expandtree:
    .. figure:: ../figs/ap/06_VariablesExpanded.png
       :name: fig.sinter.ap.expandtree
 
@@ -47,7 +44,6 @@ Aspen Plus Configuration
    **Lookup** or **Preview** (which automatically causes the tree to
    expand and selects selected variables in the **Variable Tree**).
 
-   .. _fig.sinter.ap.selectvar:
    .. figure:: ../figs/ap/07_VariablesSelected.png
       :name: fig.sinter.ap.selectvar
 
@@ -59,7 +55,6 @@ Aspen Plus Configuration
    variable, fix the **Description**, and enter the **Min/Max** fields
    by clicking on the appropriate text and entering it.
 
-   .. _fig.sinter.ap.inputvar:
    .. figure:: ../figs/ap/08_VariablesInput.png
       :alt: SinterConfigGUI Variable Configuration Page Input Variable
       :name: fig.sinter.ap.inputvar
@@ -70,7 +65,6 @@ Aspen Plus Configuration
    Output**. Next, update the fields as with the **Input Variable** to
    give a better **Name** and **Description**.
 
-   .. _fig.sinter.ap.outputvar:
    .. figure:: ../figs/ap/09_VariablesOutput.png
       :alt: SinterConfigGUI Variable Configuration Page Output Variable
       :name: fig.sinter.ap.outputvar

--- a/docs/source/chapt_sinter/tutorial/ap.rst
+++ b/docs/source/chapt_sinter/tutorial/ap.rst
@@ -9,7 +9,7 @@ Aspen Plus Configuration
    Open the Aspen Plus file and enter the metadata as shown in Figure
    :ref:`fig.sinter.ap.metadata`.
 
-   .. _fig.sinter.ap.metadata
+   .. _fig.sinter.ap.metadata:
    .. figure:: ../figs/ap/04_MetaDataFilled.png
       :alt: SinterConfigGUI Simulation Meta-Data with Data Completed
       :name: fig.sinter.ap.metadata
@@ -24,7 +24,7 @@ Aspen Plus Configuration
    Aspen Plus Tools :math:`\rightarrow` Variable Explorer.
    Unfortunately, searching is not possible.
 
-   .. _fig.sinter.ap.variableempty
+   .. _fig.sinter.ap.variableempty:
    .. figure:: ../figs/ap/05_VariablesEmpty.png
       :alt: SinterConfigGUI Variable Configuration Page Empty Variables
       :name: fig.sinter.ap.variableempty
@@ -34,7 +34,7 @@ Aspen Plus Configuration
 #. **Variable Tree** nodes can be expanded for searching (Figure
    :ref:`fig.sinter.ap.expandtree`).
 
-   .. _fig.sinter.ap.expandtree
+   .. _fig.sinter.ap.expandtree:
    .. figure:: ../figs/ap/06_VariablesExpanded.png
       :name: fig.sinter.ap.expandtree
 
@@ -47,7 +47,7 @@ Aspen Plus Configuration
    **Lookup** or **Preview** (which automatically causes the tree to
    expand and selects selected variables in the **Variable Tree**).
 
-   .. _fig.sinter.ap.selectvar
+   .. _fig.sinter.ap.selectvar:
    .. figure:: ../figs/ap/07_VariablesSelected.png
       :name: fig.sinter.ap.selectvar
 
@@ -59,7 +59,7 @@ Aspen Plus Configuration
    variable, fix the **Description**, and enter the **Min/Max** fields
    by clicking on the appropriate text and entering it.
 
-   .. _fig.sinter.ap.inputvar
+   .. _fig.sinter.ap.inputvar:
    .. figure:: ../figs/ap/08_VariablesInput.png
       :alt: SinterConfigGUI Variable Configuration Page Input Variable
       :name: fig.sinter.ap.inputvar
@@ -70,7 +70,7 @@ Aspen Plus Configuration
    Output**. Next, update the fields as with the **Input Variable** to
    give a better **Name** and **Description**.
 
-   .. _fig.sinter.ap.outputvar
+   .. _fig.sinter.ap.outputvar:
    .. figure:: ../figs/ap/09_VariablesOutput.png
       :alt: SinterConfigGUI Variable Configuration Page Output Variable
       :name: fig.sinter.ap.outputvar

--- a/docs/source/chapt_sinter/tutorial/excel.rst
+++ b/docs/source/chapt_sinter/tutorial/excel.rst
@@ -14,7 +14,6 @@ Microsoft Excel Configuration
    click the splash screen to proceed, or wait 10 seconds for it to
    close automatically.
 
-   .. _fig.sinter.excel.splash:
    .. figure:: ../figs/ap/01_Splash_Screen.png
       :alt: SinterConfigGUI Splash Screen
       :name: fig.sinter.excel.splash
@@ -31,7 +30,6 @@ Microsoft Excel Configuration
 
    C:\SimSinterFiles\\ Excel_Install_Test\exceltest.xlsm.
 
-   .. _fig.sinter.excel.openpage:
    .. figure:: ../figs/ap/02_FileOpenScreen.png
       :alt: SinterConfigGUI Open Simulation Screen
       :name: fig.sinter.excel.openpage
@@ -50,7 +48,6 @@ Microsoft Excel Configuration
    file name; however, the user must confirm the correct file location,
    since it automatically overwrites whatever filename currently exists.
 
-   .. _fig.sinter.excel.savename:
    .. figure:: ../figs/Excel/04_MetaDataSave.png
       :alt: SinterConfigGUI Simulation Meta-Data Save Text Box
       :name: fig.sinter.excel.savename
@@ -68,7 +65,6 @@ Microsoft Excel Configuration
    text box. If the default is left blank, no macro is run (unless a
    name is supplied in the input variables when running the simulation).
 
-   .. _fig.sinter.excel.variableempty:
    .. figure:: ../figs/Excel/06_VariablesEmpty.png
       :alt: SinterConfigGUI Variable Configuration Page before Input
       :name: fig.sinter.excel.variableempty
@@ -87,7 +83,6 @@ Microsoft Excel Configuration
    Note: Row is first in the **Variable Tree**, yet column is first in
    the **Path**.
 
-   .. _fig.sinter.excel.variableselected:
    .. figure:: ../figs/Excel/07_VariablesSelected.png
       :name: fig.sinter.excel.variableselected
 
@@ -101,7 +96,6 @@ Microsoft Excel Configuration
    Input Variables** section, and its meta-data may be edited (Figure
    :ref:`fig.sinter.excel.variableinputs`).
 
-   .. _fig.sinter.excel.variableinputs:
    .. figure:: ../figs/Excel/08_VariablesInput.png
       :name: fig.sinter.excel.variableinputs
 
@@ -112,7 +106,6 @@ Microsoft Excel Configuration
    variables in the **Variable Tree**, clicking **Preview**, and then
    clicking **Make Output** (Figure :ref:`fig.sinter.excel.variableoutput`).
 
-   .. _fig.sinter.excel.variableoutput:
    .. figure:: ../figs/Excel/09_VariablesOutput.png
       :name: fig.sinter.excel.variableoutput
 

--- a/docs/source/chapt_sinter/tutorial/excel.rst
+++ b/docs/source/chapt_sinter/tutorial/excel.rst
@@ -14,7 +14,7 @@ Microsoft Excel Configuration
    click the splash screen to proceed, or wait 10 seconds for it to
    close automatically.
 
-   .. _fig.sinter.excel.splash
+   .. _fig.sinter.excel.splash:
    .. figure:: ../figs/ap/01_Splash_Screen.png
       :alt: SinterConfigGUI Splash Screen
       :name: fig.sinter.excel.splash
@@ -31,7 +31,7 @@ Microsoft Excel Configuration
 
    C:\SimSinterFiles\\ Excel_Install_Test\exceltest.xlsm.
 
-   .. _fig.sinter.excel.openpage
+   .. _fig.sinter.excel.openpage:
    .. figure:: ../figs/ap/02_FileOpenScreen.png
       :alt: SinterConfigGUI Open Simulation Screen
       :name: fig.sinter.excel.openpage
@@ -50,7 +50,7 @@ Microsoft Excel Configuration
    file name; however, the user must confirm the correct file location,
    since it automatically overwrites whatever filename currently exists.
 
-   .. _fig.sinter.excel.savename
+   .. _fig.sinter.excel.savename:
    .. figure:: ../figs/Excel/04_MetaDataSave.png
       :alt: SinterConfigGUI Simulation Meta-Data Save Text Box
       :name: fig.sinter.excel.savename
@@ -68,7 +68,7 @@ Microsoft Excel Configuration
    text box. If the default is left blank, no macro is run (unless a
    name is supplied in the input variables when running the simulation).
 
-   .. _fig.sinter.excel.variableempty
+   .. _fig.sinter.excel.variableempty:
    .. figure:: ../figs/Excel/06_VariablesEmpty.png
       :alt: SinterConfigGUI Variable Configuration Page before Input
       :name: fig.sinter.excel.variableempty
@@ -87,7 +87,7 @@ Microsoft Excel Configuration
    Note: Row is first in the **Variable Tree**, yet column is first in
    the **Path**.
 
-   .. _fig.sinter.excel.variableselected
+   .. _fig.sinter.excel.variableselected:
    .. figure:: ../figs/Excel/07_VariablesSelected.png
       :name: fig.sinter.excel.variableselected
 
@@ -101,7 +101,7 @@ Microsoft Excel Configuration
    Input Variables** section, and its meta-data may be edited (Figure
    :ref:`fig.sinter.excel.variableinputs`).
 
-   .. _fig.sinter.excel.variableinputs
+   .. _fig.sinter.excel.variableinputs:
    .. figure:: ../figs/Excel/08_VariablesInput.png
       :name: fig.sinter.excel.variableinputs
 
@@ -112,7 +112,7 @@ Microsoft Excel Configuration
    variables in the **Variable Tree**, clicking **Preview**, and then
    clicking **Make Output** (Figure :ref:`fig.sinter.excel.variableoutput`).
 
-   .. _fig.sinter.excel.variableoutput
+   .. _fig.sinter.excel.variableoutput:
    .. figure:: ../figs/Excel/09_VariablesOutput.png
       :name: fig.sinter.excel.variableoutput
 

--- a/docs/source/chapt_sinter/tutorial/gproms.rst
+++ b/docs/source/chapt_sinter/tutorial/gproms.rst
@@ -44,7 +44,7 @@ variable where gPROMS will use the data.
    Double-click on the .gPJ file to open ModelBuilder, as shown in
    Figure :ref:`fig.sinter.gproms.openbuffertank`.
 
-   .. _fig.sinter.gproms.openbuffertank
+   .. _fig.sinter.gproms.openbuffertank:
    .. figure:: ../figs/gPROMS/01_OpenBufferTank.png
       :alt: Opening BufferTank in gPROMS Model Builder
       :name: fig.sinter.gproms.openbuffertank
@@ -61,7 +61,7 @@ variable where gPROMS will use the data.
    simulation will change some of these PARAMETERS and VARIABLES to
    change the output of the simulation.
 
-   .. _fig.sinter.gproms.viewbuffertank
+   .. _fig.sinter.gproms.viewbuffertank:
    .. figure:: ../figs/gPROMS/02_EditBufferTank.png
       :alt: Viewing BufferTank in gPROMS Model Builder
       :name: fig.sinter.gproms.viewbuffertank
@@ -75,7 +75,7 @@ variable where gPROMS will use the data.
    setting values with Sinter. The “SimulateTank_Sinter” example will be
    recreated in this tutorial.
 
-   .. _fig.sinter.gproms.viewsimulatetank
+   .. _fig.sinter.gproms.viewsimulatetank:
    .. figure:: ../figs/gPROMS/03_EditBufferTank.png
       :alt: Viewing SimulateTank in gPROMS Model Builder
       :name: fig.sinter.gproms.viewsimulatetank
@@ -84,7 +84,7 @@ variable where gPROMS will use the data.
 
 #. First copy the existing hard-coded Process “SimulateTank”.
 
-   .. _fig.sinter.gproms.copysimulatetank
+   .. _fig.sinter.gproms.copysimulatetank:
    .. figure:: ../figs/gPROMS/04_EditBufferTank.png
       :alt: Copying SimulateTank
       :name: fig.sinter.gproms.copysimulatetank
@@ -93,7 +93,7 @@ variable where gPROMS will use the data.
 
 #. Right-click on Processes and select **Paste** to make a new process.
 
-   .. _fig.sinter.gproms.pastesimulatetank
+   .. _fig.sinter.gproms.pastesimulatetank:
    .. figure:: ../figs/gPROMS/05_EditBufferTank.png
       :alt: Paste SimulateTank
       :name: fig.sinter.gproms.pastesimulatetank
@@ -103,7 +103,7 @@ variable where gPROMS will use the data.
 #. The new process will be named “SimulateTank_1”. Rename the process by
    right-clicking on it and selecting **Rename**.
 
-   .. _fig.sinter.gproms.renamesimulatetank
+   .. _fig.sinter.gproms.renamesimulatetank:
    .. figure:: ../figs/gPROMS/06_EditBufferTank.png
       :alt: Rename SimulateTank
       :name: fig.sinter.gproms.renamesimulatetank
@@ -113,19 +113,19 @@ variable where gPROMS will use the data.
 #. Now open up the new “SimulateTank_tutorial” Process. It has the same
    hard-coded values as “SimulateTank”.
 
-   .. figure:: ../figs/gPROMS/07_EditBufferTank.png
+   .. _fig.sinter.gproms.opensimulatetank_tutorial:
+   .. figure:: ../figs/gPROMS/07_EditBufferTank.png:
       :alt: Opening SimulateTank_tutorial
+      :name: fig.sinter.gproms.opensimulatetank_tutorial
 
       Opening SimulateTank_tutorial
-
-   [fig.sinter.gproms.opensimulatetank_tutorial]
 
 #. First, the user needs to add a FOREIGN_OBJECT named “FO” in the
    PARAMETER section. Then the user needs to set that FOREIGN_OBJECT to
    “SimpleEventFOI::dummy” in the SET section. This FOREIGN_OBJECT is
    how inputs are received from SimSinter.
 
-   .. _fig.sinter.gproms.foreignobject
+   .. _fig.sinter.gproms.foreignobject:
    .. figure:: ../figs/gPROMS/08_EditBufferTank.png
       :alt: Adding the FOREIGN_OBJECT
       :name: fig.sinter.gproms.foreignobject
@@ -160,7 +160,7 @@ variable where gPROMS will use the data.
    For this example the user only really needs to set “T101.Alpha” in
    PARAMETER, “T101.FlowIn” in ASSIGN, and “T101.Height” in INITIAL.
 
-   .. _fig.sinter.gproms.setupinputvariables
+   .. _fig.sinter.gproms.setupinputvariables:
    .. figure:: ../figs/gPROMS/09_EditBufferTank.png
       :alt: Setting up Input Variables
       :name: fig.sinter.gproms.setupinputvariables
@@ -180,7 +180,7 @@ variable where gPROMS will use the data.
       REAL__FlowInFO = 14
       REAL__HeightFO = 7.5
 
-   .. _fig.sinter.gproms.testingtutorial
+   .. _fig.sinter.gproms.testingtutorial:
    .. figure:: ../figs/gPROMS/10_EditBufferTank.png
       :alt: Testing SimulateTank_Tutorial
       :name: fig.sinter.gproms.testingtutorial
@@ -198,7 +198,7 @@ to export that process for use by SimSinter.
 #. Right-click on the Process to export (“SimulateTank_tutorial”) and
    select **Export**.
 
-   .. _fig.sinter.gproms.selectexport
+   .. _fig.sinter.gproms.selectexport:
    .. figure:: ../figs/gPROMS/11_Export.png
       :alt: Select “Export”
       :name: fig.sinter.gproms.selectexport
@@ -208,7 +208,7 @@ to export that process for use by SimSinter.
 #. In the resulting Export window, select **Encrypted input file for
    simulation by gO:RUN** and click **OK**.
 
-   .. _fig.sinter.gproms.selectencrypted
+   .. _fig.sinter.gproms.selectencrypted:
    .. figure:: ../figs/gPROMS/12_Export.png
       :alt: Select “Encrypted Input File”
       :name: fig.sinter.gproms.selectencrypted
@@ -225,7 +225,7 @@ to export that process for use by SimSinter.
    has the original file. SimSinter does not use it. When the user has
    finished setting up these fields, click **Export Entity**.
 
-   .. _fig.sinter.gproms.exportentity
+   .. _fig.sinter.gproms.exportentity:
    .. figure:: ../figs/gPROMS/13_Export.png
       :alt: Export Entity Page
       :name: fig.sinter.gproms.exportentity
@@ -255,7 +255,7 @@ configuration can be done.
    may click the splash screen to proceed, or wait 10 seconds for it to
    close automatically.
 
-   .. _fig.sinter.gproms.splash
+   .. _fig.sinter.gproms.splash:
    .. figure:: ../figs/ap/01_Splash_Screen.png
       :alt: SinterConfigGUI Splash Screen
       :name: fig.sinter.gproms.splash
@@ -277,7 +277,7 @@ configuration can be done.
    Once the file is selected, click **Open File and Configure
    Variables.**
 
-   .. _fig.sinter.gproms.openpage
+   .. _fig.sinter.gproms.openpage:
    .. figure:: ../figs/ap/02_FileOpenScreen.png
       :alt: SinterConfigGUI Open Simulation Screen
       :name: fig.sinter.gproms.openpage
@@ -298,7 +298,7 @@ configuration can be done.
    fields to provide the meta-data to describe the simulation that was
    just opened and then click **Next**.
 
-   .. _fig.sinter.gproms.savename
+   .. _fig.sinter.gproms.savename:
    .. figure:: ../figs/gPROMS/17_MetaDataPage.png
       :alt: SinterConfigGUI Simulation Meta-Data Save Text Box
       :name: fig.sinter.gproms.savename
@@ -315,7 +315,7 @@ configuration can be done.
    The root is connected to the three processes defined in this .gPJ
    file. First, change the **ProcessName** to “SimulateTank_tutorial”.
 
-   .. _fig.sinter.gproms.settings
+   .. _fig.sinter.gproms.settings:
    .. figure:: ../figs/gPROMS/18_Settings.png
       :alt: SinterConfigGUI gPROMS Settings Configuration
       :name: fig.sinter.gproms.settings
@@ -350,7 +350,7 @@ configuration can be done.
    **Min** and **Max** values are taken from the variable type, if there
    is one.
 
-   .. _fig.sinter.gproms.inputs
+   .. _fig.sinter.gproms.inputs:
    .. figure:: ../figs/gPROMS/19_InputVariables.png
       :alt: SinterConfigGUI Automatically Displays Input Variables
       :name: fig.sinter.gproms.inputs
@@ -364,7 +364,7 @@ configuration can be done.
    As stated above, the user cannot make new Input Variables in
    SinterConfigGUI. Only **Make Output** is allowed.
 
-   .. _fig.sinter.gproms.outputs1
+   .. _fig.sinter.gproms.outputs1:
    .. figure:: ../figs/gPROMS/20_OutputVariables.png
       :alt: Preview of the FlowOut Variable
       :name: fig.sinter.gproms.outputs1
@@ -376,7 +376,7 @@ configuration can be done.
    Description can be updated, but SimSinter made a good guess in this
    example; therefore, there is no need to change the description.
 
-   .. _fig.sinter.gproms.outputs2
+   .. _fig.sinter.gproms.outputs2:
    .. figure:: ../figs/gPROMS/21_OutputVariables.png
       :alt: FlowOut as an Input Variable
       :name: fig.sinter.gproms.outputs2
@@ -385,7 +385,7 @@ configuration can be done.
 
 #. By the same method, make Output Variables “HoldUp” and “Height.”
 
-   .. _fig.sinter.gproms.outputs3
+   .. _fig.sinter.gproms.outputs3:
    .. figure:: ../figs/gPROMS/22_OutputVariables.png
       :alt: HoldUp and Height Output Variables
       :name: fig.sinter.gproms.outputs3
@@ -395,7 +395,7 @@ configuration can be done.
 #. The variables names should be made shorter. Simply click on the
    **Name** column and change the name to your preferred name.
 
-   .. _fig.sinter.gproms.outputs4
+   .. _fig.sinter.gproms.outputs4:
    .. figure:: ../figs/gPROMS/23_OutputVariables.png
       :alt: Editing Variable Names
       :name: fig.sinter.gproms.outputs4
@@ -411,7 +411,7 @@ configuration can be done.
       FlowInFO = 14
       HeightFO = 7.5
 
-   .. _fig.sinter.gproms.defaults
+   .. _fig.sinter.gproms.defaults:
    .. figure:: ../figs/gPROMS/24_Defaults.png
       :alt: Editing Defaults
       :name: fig.sinter.gproms.defaults
@@ -423,7 +423,7 @@ configuration can be done.
    Default Initialization page will display. Here the default values of
    the vectors may be edited.
 
-   .. _fig.sinter.gproms.vectors
+   .. _fig.sinter.gproms.vectors:
    .. figure:: ../figs/gPROMS/25_Vectorss.png
       :alt: Editing Vectors
       :name: fig.sinter.gproms.vectors

--- a/docs/source/chapt_sinter/tutorial/gproms.rst
+++ b/docs/source/chapt_sinter/tutorial/gproms.rst
@@ -44,7 +44,6 @@ variable where gPROMS will use the data.
    Double-click on the .gPJ file to open ModelBuilder, as shown in
    Figure :ref:`fig.sinter.gproms.openbuffertank`.
 
-   .. _fig.sinter.gproms.openbuffertank:
    .. figure:: ../figs/gPROMS/01_OpenBufferTank.png
       :alt: Opening BufferTank in gPROMS Model Builder
       :name: fig.sinter.gproms.openbuffertank
@@ -61,7 +60,6 @@ variable where gPROMS will use the data.
    simulation will change some of these PARAMETERS and VARIABLES to
    change the output of the simulation.
 
-   .. _fig.sinter.gproms.viewbuffertank:
    .. figure:: ../figs/gPROMS/02_EditBufferTank.png
       :alt: Viewing BufferTank in gPROMS Model Builder
       :name: fig.sinter.gproms.viewbuffertank
@@ -75,7 +73,6 @@ variable where gPROMS will use the data.
    setting values with Sinter. The “SimulateTank_Sinter” example will be
    recreated in this tutorial.
 
-   .. _fig.sinter.gproms.viewsimulatetank:
    .. figure:: ../figs/gPROMS/03_EditBufferTank.png
       :alt: Viewing SimulateTank in gPROMS Model Builder
       :name: fig.sinter.gproms.viewsimulatetank
@@ -84,7 +81,6 @@ variable where gPROMS will use the data.
 
 #. First copy the existing hard-coded Process “SimulateTank”.
 
-   .. _fig.sinter.gproms.copysimulatetank:
    .. figure:: ../figs/gPROMS/04_EditBufferTank.png
       :alt: Copying SimulateTank
       :name: fig.sinter.gproms.copysimulatetank
@@ -93,7 +89,6 @@ variable where gPROMS will use the data.
 
 #. Right-click on Processes and select **Paste** to make a new process.
 
-   .. _fig.sinter.gproms.pastesimulatetank:
    .. figure:: ../figs/gPROMS/05_EditBufferTank.png
       :alt: Paste SimulateTank
       :name: fig.sinter.gproms.pastesimulatetank
@@ -103,7 +98,6 @@ variable where gPROMS will use the data.
 #. The new process will be named “SimulateTank_1”. Rename the process by
    right-clicking on it and selecting **Rename**.
 
-   .. _fig.sinter.gproms.renamesimulatetank:
    .. figure:: ../figs/gPROMS/06_EditBufferTank.png
       :alt: Rename SimulateTank
       :name: fig.sinter.gproms.renamesimulatetank
@@ -113,8 +107,7 @@ variable where gPROMS will use the data.
 #. Now open up the new “SimulateTank_tutorial” Process. It has the same
    hard-coded values as “SimulateTank”.
 
-   .. _fig.sinter.gproms.opensimulatetank_tutorial:
-   .. figure:: ../figs/gPROMS/07_EditBufferTank.png:
+   .. figure:: ../figs/gPROMS/07_EditBufferTank.png
       :alt: Opening SimulateTank_tutorial
       :name: fig.sinter.gproms.opensimulatetank_tutorial
 
@@ -125,7 +118,6 @@ variable where gPROMS will use the data.
    “SimpleEventFOI::dummy” in the SET section. This FOREIGN_OBJECT is
    how inputs are received from SimSinter.
 
-   .. _fig.sinter.gproms.foreignobject:
    .. figure:: ../figs/gPROMS/08_EditBufferTank.png
       :alt: Adding the FOREIGN_OBJECT
       :name: fig.sinter.gproms.foreignobject
@@ -160,7 +152,6 @@ variable where gPROMS will use the data.
    For this example the user only really needs to set “T101.Alpha” in
    PARAMETER, “T101.FlowIn” in ASSIGN, and “T101.Height” in INITIAL.
 
-   .. _fig.sinter.gproms.setupinputvariables:
    .. figure:: ../figs/gPROMS/09_EditBufferTank.png
       :alt: Setting up Input Variables
       :name: fig.sinter.gproms.setupinputvariables
@@ -180,7 +171,6 @@ variable where gPROMS will use the data.
       REAL__FlowInFO = 14
       REAL__HeightFO = 7.5
 
-   .. _fig.sinter.gproms.testingtutorial:
    .. figure:: ../figs/gPROMS/10_EditBufferTank.png
       :alt: Testing SimulateTank_Tutorial
       :name: fig.sinter.gproms.testingtutorial
@@ -198,7 +188,6 @@ to export that process for use by SimSinter.
 #. Right-click on the Process to export (“SimulateTank_tutorial”) and
    select **Export**.
 
-   .. _fig.sinter.gproms.selectexport:
    .. figure:: ../figs/gPROMS/11_Export.png
       :alt: Select “Export”
       :name: fig.sinter.gproms.selectexport
@@ -208,7 +197,6 @@ to export that process for use by SimSinter.
 #. In the resulting Export window, select **Encrypted input file for
    simulation by gO:RUN** and click **OK**.
 
-   .. _fig.sinter.gproms.selectencrypted:
    .. figure:: ../figs/gPROMS/12_Export.png
       :alt: Select “Encrypted Input File”
       :name: fig.sinter.gproms.selectencrypted
@@ -225,7 +213,6 @@ to export that process for use by SimSinter.
    has the original file. SimSinter does not use it. When the user has
    finished setting up these fields, click **Export Entity**.
 
-   .. _fig.sinter.gproms.exportentity:
    .. figure:: ../figs/gPROMS/13_Export.png
       :alt: Export Entity Page
       :name: fig.sinter.gproms.exportentity
@@ -255,7 +242,6 @@ configuration can be done.
    may click the splash screen to proceed, or wait 10 seconds for it to
    close automatically.
 
-   .. _fig.sinter.gproms.splash:
    .. figure:: ../figs/ap/01_Splash_Screen.png
       :alt: SinterConfigGUI Splash Screen
       :name: fig.sinter.gproms.splash
@@ -277,7 +263,6 @@ configuration can be done.
    Once the file is selected, click **Open File and Configure
    Variables.**
 
-   .. _fig.sinter.gproms.openpage:
    .. figure:: ../figs/ap/02_FileOpenScreen.png
       :alt: SinterConfigGUI Open Simulation Screen
       :name: fig.sinter.gproms.openpage
@@ -298,7 +283,6 @@ configuration can be done.
    fields to provide the meta-data to describe the simulation that was
    just opened and then click **Next**.
 
-   .. _fig.sinter.gproms.savename:
    .. figure:: ../figs/gPROMS/17_MetaDataPage.png
       :alt: SinterConfigGUI Simulation Meta-Data Save Text Box
       :name: fig.sinter.gproms.savename
@@ -315,7 +299,6 @@ configuration can be done.
    The root is connected to the three processes defined in this .gPJ
    file. First, change the **ProcessName** to “SimulateTank_tutorial”.
 
-   .. _fig.sinter.gproms.settings:
    .. figure:: ../figs/gPROMS/18_Settings.png
       :alt: SinterConfigGUI gPROMS Settings Configuration
       :name: fig.sinter.gproms.settings
@@ -350,7 +333,6 @@ configuration can be done.
    **Min** and **Max** values are taken from the variable type, if there
    is one.
 
-   .. _fig.sinter.gproms.inputs:
    .. figure:: ../figs/gPROMS/19_InputVariables.png
       :alt: SinterConfigGUI Automatically Displays Input Variables
       :name: fig.sinter.gproms.inputs
@@ -364,7 +346,6 @@ configuration can be done.
    As stated above, the user cannot make new Input Variables in
    SinterConfigGUI. Only **Make Output** is allowed.
 
-   .. _fig.sinter.gproms.outputs1:
    .. figure:: ../figs/gPROMS/20_OutputVariables.png
       :alt: Preview of the FlowOut Variable
       :name: fig.sinter.gproms.outputs1
@@ -376,7 +357,6 @@ configuration can be done.
    Description can be updated, but SimSinter made a good guess in this
    example; therefore, there is no need to change the description.
 
-   .. _fig.sinter.gproms.outputs2:
    .. figure:: ../figs/gPROMS/21_OutputVariables.png
       :alt: FlowOut as an Input Variable
       :name: fig.sinter.gproms.outputs2
@@ -385,7 +365,6 @@ configuration can be done.
 
 #. By the same method, make Output Variables “HoldUp” and “Height.”
 
-   .. _fig.sinter.gproms.outputs3:
    .. figure:: ../figs/gPROMS/22_OutputVariables.png
       :alt: HoldUp and Height Output Variables
       :name: fig.sinter.gproms.outputs3
@@ -395,7 +374,6 @@ configuration can be done.
 #. The variables names should be made shorter. Simply click on the
    **Name** column and change the name to your preferred name.
 
-   .. _fig.sinter.gproms.outputs4:
    .. figure:: ../figs/gPROMS/23_OutputVariables.png
       :alt: Editing Variable Names
       :name: fig.sinter.gproms.outputs4
@@ -411,7 +389,6 @@ configuration can be done.
       FlowInFO = 14
       HeightFO = 7.5
 
-   .. _fig.sinter.gproms.defaults:
    .. figure:: ../figs/gPROMS/24_Defaults.png
       :alt: Editing Defaults
       :name: fig.sinter.gproms.defaults
@@ -423,7 +400,6 @@ configuration can be done.
    Default Initialization page will display. Here the default values of
    the vectors may be edited.
 
-   .. _fig.sinter.gproms.vectors:
    .. figure:: ../figs/gPROMS/25_Vectorss.png
       :alt: Editing Vectors
       :name: fig.sinter.gproms.vectors

--- a/docs/source/chapt_surrogates/reference.rst
+++ b/docs/source/chapt_surrogates/reference.rst
@@ -40,7 +40,6 @@ associated with a flowsheet data (results from a single flowsheet run,
 optimization runs, or UQ samples), then the flowsheet data is available
 to be the training data and the table will be populated accordingly.
 
-.. _fig.surrogate.data:
 .. figure:: figs/data_form.svg
    :alt: Surrogate Data Form
    :name: fig.surrogate.data
@@ -113,7 +112,6 @@ indicates that it should be included in the surrogate generation.
 Failure to select a checkbox for any variables will result in error
 during surrogate generation.
 
-.. _fig.surrogate.vars:
 .. figure:: figs/vars.svg
    :alt: Surrogate Variable Selection
    :name: fig.surrogate.vars
@@ -128,7 +126,6 @@ The **Method Settings** table is illustrated in Figure
 available in this table depend on the surrogate tool. A description of
 each setting is provided in the third column of the table.
 
-.. _fig.surrogate.settings:
 .. figure:: figs/settings.svg
    :alt: Surrogate Settings
    :name: fig.surrogate.settings
@@ -144,7 +141,6 @@ execution monitor displays after **Run** is clicked (see Figure
 monitor displays the status of the surrogate build. The messages
 displayed depends on the surrogate tool.
 
-.. _fig.surrogate.monitor:
 .. figure:: figs/monitor.svg
    :alt: Surrogate Status Monitor
    :name: fig.surrogate.monitor

--- a/docs/source/chapt_surrogates/reference.rst
+++ b/docs/source/chapt_surrogates/reference.rst
@@ -40,7 +40,7 @@ associated with a flowsheet data (results from a single flowsheet run,
 optimization runs, or UQ samples), then the flowsheet data is available
 to be the training data and the table will be populated accordingly.
 
-.. _fig.surrogate.data
+.. _fig.surrogate.data:
 .. figure:: figs/data_form.svg
    :alt: Surrogate Data Form
    :name: fig.surrogate.data
@@ -113,7 +113,7 @@ indicates that it should be included in the surrogate generation.
 Failure to select a checkbox for any variables will result in error
 during surrogate generation.
 
-.. _fig.surrogate.vars
+.. _fig.surrogate.vars:
 .. figure:: figs/vars.svg
    :alt: Surrogate Variable Selection
    :name: fig.surrogate.vars
@@ -128,7 +128,7 @@ The **Method Settings** table is illustrated in Figure
 available in this table depend on the surrogate tool. A description of
 each setting is provided in the third column of the table.
 
-.. _fig.surrogate.settings
+.. _fig.surrogate.settings:
 .. figure:: figs/settings.svg
    :alt: Surrogate Settings
    :name: fig.surrogate.settings
@@ -144,7 +144,7 @@ execution monitor displays after **Run** is clicked (see Figure
 monitor displays the status of the surrogate build. The messages
 displayed depends on the surrogate tool.
 
-.. _fig.surrogate.monitor
+.. _fig.surrogate.monitor:
 .. figure:: figs/monitor.svg
    :alt: Surrogate Status Monitor
    :name: fig.surrogate.monitor

--- a/docs/source/chapt_surrogates/tutorial/acosso.rst
+++ b/docs/source/chapt_surrogates/tutorial/acosso.rst
@@ -75,7 +75,6 @@ FOQUS.
 
 #. Click the **Run** icon (Figure :ref:`fig.acosso.settings`).
 
-.. _fig.acosso.settings:
 .. figure:: ../figs/acosso_settings.svg
    :alt: ACOSSO Session Set Up
    :name: fig.acosso.settings

--- a/docs/source/chapt_surrogates/tutorial/acosso.rst
+++ b/docs/source/chapt_surrogates/tutorial/acosso.rst
@@ -75,7 +75,7 @@ FOQUS.
 
 #. Click the **Run** icon (Figure :ref:`fig.acosso.settings`).
 
-.. _fig.acosso.settings
+.. _fig.acosso.settings:
 .. figure:: ../figs/acosso_settings.svg
    :alt: ACOSSO Session Set Up
    :name: fig.acosso.settings

--- a/docs/source/chapt_surrogates/tutorial/alamo.rst
+++ b/docs/source/chapt_surrogates/tutorial/alamo.rst
@@ -24,7 +24,6 @@ Flowsheet Setup
 #. Name the session “Surrogate_Tutorial_1” (Figure
    :ref:`fig.tut.sur.session`).
 
-.. _fig.tut.sur.session:
 .. figure:: ../figs/session1.svg
    :alt: Session Set Up
    :name: fig.tut.sur.session
@@ -39,7 +38,6 @@ Flowsheet Setup
 5. Display the Node Editor by clicking the **Node Editor** toggle
    button.
 
-.. _fig.tut.sur.flowsheet:
 .. figure:: ../figs/flowsheet.svg
    :alt: Flowsheet Setup
    :name: fig.tut.sur.flowsheet
@@ -63,7 +61,6 @@ and output variables to the node.
 
 9. Add two output variables “z1” and “z2.”
 
-.. _fig.tut.sur.nodeEdit.Input:
 .. figure:: ../figs/nodeInput.svg
    :alt: Node Variables
    :name: fig.tut.sur.nodeEdit.Input
@@ -89,7 +86,6 @@ simulation model and calculations are performed directly in FOQUS.
     “f” stores output values while the dictionary “x” stores input
     values.
 
-    .. _fig.tut.sur.nodeEdit.eq:
     .. figure:: ../figs/nodeEq.svg
        :alt: Node Script
        :name: fig.tut.sur.nodeEdit.eq
@@ -117,7 +113,6 @@ data is provided and adaptive sampling is used.
 15. The **Add New Ensemble - Model Selection** dialog will appear. Click
     **OK** to set up the sampling scheme.
 
-.. _fig.tut.sur.new.uq.ens:
 .. figure:: ../figs/uqNewEns.svg
    :alt: Add a New Sample Ensemble
    :name: fig.tut.sur.new.uq.ens
@@ -132,7 +127,6 @@ data is provided and adaptive sampling is used.
 
 18. Select the **Sampling scheme** tab.
 
-.. _fig.tut.sur.new.uq.sample1:
 .. figure:: ../figs/uqSample1.svg
    :alt: Sample Distributions
    :name: fig.tut.sur.new.uq.sample1
@@ -149,7 +143,6 @@ data is provided and adaptive sampling is used.
 
 22. Click **Done**.
 
-.. _fig.tut.sur.new.uq.sample2:
 .. figure:: ../figs/uqSample2.svg
    :alt: Sample Methods
    :name: fig.tut.sur.new.uq.sample2
@@ -160,7 +153,6 @@ data is provided and adaptive sampling is used.
     in the UQ tool window (Figure :ref:`fig.tut.sur.new.uq.sample3`).
     Click **Launch** to run and generate the samples.
 
-.. _fig.tut.sur.new.uq.sample3:
 .. figure:: ../figs/uqSample3.svg
    :alt: Run Samples
    :name: fig.tut.sur.new.uq.sample3
@@ -183,7 +175,6 @@ single test run from the UQ samples.
 26. Click **Edit Filters** in the **Flowsheet Results** section to
     create a filter.
 
-.. _fig.tut.sur.data:
 .. figure:: ../figs/data.svg
    :alt: Surrogate Data
    :name: fig.tut.sur.data
@@ -207,7 +198,6 @@ single test run from the UQ samples.
 
 29. Click **Done**.
 
-.. _fig.tut.sur.dataFilter:
 .. figure:: ../figs/dataFilter.svg
    :alt: Data Filter Dialog
    :name: fig.tut.sur.dataFilter
@@ -232,7 +222,6 @@ selecting more.
 
 32. Select the checkbox for both output variables.
 
-.. _fig.tut.sur.vaiables:
 .. figure:: ../figs/variables.svg
    :alt: Variable Selection
    :name: fig.tut.sur.vaiables
@@ -276,7 +265,6 @@ the following format: [element 1, element 2].
 42. Save this FOQUS session for use in the ACOSSO and BSS-ANOVA
     tutorials.
 
-.. _fig.alamo.method.settigs:
 .. figure:: ../figs/alamo_settings.svg
    :alt: ALAMO Method Settings
    :name: fig.alamo.method.settigs
@@ -307,7 +295,6 @@ Execution
     #. Finally, the statistics display the quality metrics of the models
        generated.
 
-.. _fig.alamo.res:
 .. figure:: ../figs/alamo_exec.svg
    :alt: ALAMO Execution
    :name: fig.alamo.res
@@ -331,6 +318,7 @@ As mentioned in section `1.5 <#tutorial.alamo.methodsettings>`__ the
 method settings are very important. A brief description and hints are
 included in Table :ref:`tutorial.alamo.table`.
 
+.. _tutorial.alamo.table:
 .. table:: ALAMO Method Settings
 
    +-----------------------------------+-----------------------------------+

--- a/docs/source/chapt_surrogates/tutorial/alamo.rst
+++ b/docs/source/chapt_surrogates/tutorial/alamo.rst
@@ -24,7 +24,7 @@ Flowsheet Setup
 #. Name the session “Surrogate_Tutorial_1” (Figure
    :ref:`fig.tut.sur.session`).
 
-.. _fig.tut.sur.session
+.. _fig.tut.sur.session:
 .. figure:: ../figs/session1.svg
    :alt: Session Set Up
    :name: fig.tut.sur.session
@@ -39,7 +39,7 @@ Flowsheet Setup
 5. Display the Node Editor by clicking the **Node Editor** toggle
    button.
 
-.. _fig.tut.sur.flowsheet
+.. _fig.tut.sur.flowsheet:
 .. figure:: ../figs/flowsheet.svg
    :alt: Flowsheet Setup
    :name: fig.tut.sur.flowsheet
@@ -63,7 +63,7 @@ and output variables to the node.
 
 9. Add two output variables “z1” and “z2.”
 
-.. _fig.tut.sur.nodeEdit.Input
+.. _fig.tut.sur.nodeEdit.Input:
 .. figure:: ../figs/nodeInput.svg
    :alt: Node Variables
    :name: fig.tut.sur.nodeEdit.Input
@@ -89,7 +89,7 @@ simulation model and calculations are performed directly in FOQUS.
     “f” stores output values while the dictionary “x” stores input
     values.
 
-    .. _fig.tut.sur.nodeEdit.eq
+    .. _fig.tut.sur.nodeEdit.eq:
     .. figure:: ../figs/nodeEq.svg
        :alt: Node Script
        :name: fig.tut.sur.nodeEdit.eq
@@ -117,7 +117,7 @@ data is provided and adaptive sampling is used.
 15. The **Add New Ensemble - Model Selection** dialog will appear. Click
     **OK** to set up the sampling scheme.
 
-.. _fig.tut.sur.new.uq.ens
+.. _fig.tut.sur.new.uq.ens:
 .. figure:: ../figs/uqNewEns.svg
    :alt: Add a New Sample Ensemble
    :name: fig.tut.sur.new.uq.ens
@@ -132,7 +132,7 @@ data is provided and adaptive sampling is used.
 
 18. Select the **Sampling scheme** tab.
 
-.. _fig.tut.sur.new.uq.sample1
+.. _fig.tut.sur.new.uq.sample1:
 .. figure:: ../figs/uqSample1.svg
    :alt: Sample Distributions
    :name: fig.tut.sur.new.uq.sample1
@@ -149,7 +149,7 @@ data is provided and adaptive sampling is used.
 
 22. Click **Done**.
 
-.. _fig.tut.sur.new.uq.sample2
+.. _fig.tut.sur.new.uq.sample2:
 .. figure:: ../figs/uqSample2.svg
    :alt: Sample Methods
    :name: fig.tut.sur.new.uq.sample2
@@ -160,7 +160,7 @@ data is provided and adaptive sampling is used.
     in the UQ tool window (Figure :ref:`fig.tut.sur.new.uq.sample3`).
     Click **Launch** to run and generate the samples.
 
-.. _fig.tut.sur.new.uq.sample3
+.. _fig.tut.sur.new.uq.sample3:
 .. figure:: ../figs/uqSample3.svg
    :alt: Run Samples
    :name: fig.tut.sur.new.uq.sample3
@@ -183,7 +183,7 @@ single test run from the UQ samples.
 26. Click **Edit Filters** in the **Flowsheet Results** section to
     create a filter.
 
-.. _fig.tut.sur.data
+.. _fig.tut.sur.data:
 .. figure:: ../figs/data.svg
    :alt: Surrogate Data
    :name: fig.tut.sur.data
@@ -207,7 +207,7 @@ single test run from the UQ samples.
 
 29. Click **Done**.
 
-.. _fig.tut.sur.dataFilter
+.. _fig.tut.sur.dataFilter:
 .. figure:: ../figs/dataFilter.svg
    :alt: Data Filter Dialog
    :name: fig.tut.sur.dataFilter
@@ -232,7 +232,7 @@ selecting more.
 
 32. Select the checkbox for both output variables.
 
-.. _fig.tut.sur.vaiables
+.. _fig.tut.sur.vaiables:
 .. figure:: ../figs/variables.svg
    :alt: Variable Selection
    :name: fig.tut.sur.vaiables
@@ -276,7 +276,7 @@ the following format: [element 1, element 2].
 42. Save this FOQUS session for use in the ACOSSO and BSS-ANOVA
     tutorials.
 
-.. _fig.alamo.method.settigs
+.. _fig.alamo.method.settigs:
 .. figure:: ../figs/alamo_settings.svg
    :alt: ALAMO Method Settings
    :name: fig.alamo.method.settigs
@@ -307,7 +307,7 @@ Execution
     #. Finally, the statistics display the quality metrics of the models
        generated.
 
-.. _fig.alamo.res
+.. _fig.alamo.res:
 .. figure:: ../figs/alamo_exec.svg
    :alt: ALAMO Execution
    :name: fig.alamo.res

--- a/docs/source/chapt_surrogates/tutorial/bssanova.rst
+++ b/docs/source/chapt_surrogates/tutorial/bssanova.rst
@@ -54,7 +54,7 @@ version 3.1 or later (see
 #. Click the **Run** icon (Figure
    :ref:`fig.bssanova.settings`).
 
-.. _fig.bssanova.settings
+.. _fig.bssanova.settings:
 .. figure:: ../figs/bssanova_settings.svg
    :alt: BSS-ANOVA Session Set Up
    :name: fig.bssanova.settings

--- a/docs/source/chapt_surrogates/tutorial/bssanova.rst
+++ b/docs/source/chapt_surrogates/tutorial/bssanova.rst
@@ -54,7 +54,6 @@ version 3.1 or later (see
 #. Click the **Run** icon (Figure
    :ref:`fig.bssanova.settings`).
 
-.. _fig.bssanova.settings:
 .. figure:: ../figs/bssanova_settings.svg
    :alt: BSS-ANOVA Session Set Up
    :name: fig.bssanova.settings

--- a/docs/source/chapt_surrogates/tutorial/flowsheet.rst
+++ b/docs/source/chapt_surrogates/tutorial/flowsheet.rst
@@ -49,7 +49,6 @@ Section :ref:`sec.surrogate.alamo`.**
 #. Check the value of the **Output Variables**; the approximate values
    should be z1 = 5 and z2 = 13.
 
-.. _fig.pg.tut1:
 .. figure:: ../figs/fs_plugin.svg
    :alt: Plugin Flowsheet
    :name: fig.pg.tut1

--- a/docs/source/chapt_surrogates/tutorial/flowsheet.rst
+++ b/docs/source/chapt_surrogates/tutorial/flowsheet.rst
@@ -49,7 +49,7 @@ Section :ref:`sec.surrogate.alamo`.**
 #. Check the value of the **Output Variables**; the approximate values
    should be z1 = 5 and z2 = 13.
 
-.. _fig.pg.tut1
+.. _fig.pg.tut1:
 .. figure:: ../figs/fs_plugin.svg
    :alt: Plugin Flowsheet
    :name: fig.pg.tut1

--- a/docs/source/chapt_uq/tutorial/sim.rst
+++ b/docs/source/chapt_uq/tutorial/sim.rst
@@ -11,7 +11,7 @@ In this tutorial, a simulation ensemble is created and run.
    “Rosenbrock_novectors.foqus" problem (Figure
    :ref:`fig.uqt_home`).
 
-   .. _fig.uqt_home
+   .. _fig.uqt_home:
    .. figure:: ../figs/tutorial/1_home2.png
       :alt: Home Screen
       :name: fig.uqt_home
@@ -23,7 +23,7 @@ In this tutorial, a simulation ensemble is created and run.
    :ref:`subsec.opt.tutorial.flowsheet`
    for a detailed example of creating a flowsheet.
 
-   .. _fig.uqt_flowsheet
+   .. _fig.uqt_flowsheet:
    .. figure:: ../figs/tutorial/2_flowsheet2.png
       :alt: Flowsheet for Rosenbrock Example
       :name: fig.uqt_flowsheet
@@ -33,7 +33,7 @@ In this tutorial, a simulation ensemble is created and run.
 #. Click the **Uncertainty** button (Figure
    :ref:`fig.uqt_uqhome`).
 
-   .. _fig.uqt_uqhome
+   .. _fig.uqt_uqhome:
    .. figure:: ../figs/tutorial/3_UQScreen2.png
       :alt: Uncertainty Quantification Screen
       :name: fig.uqt_uqhome
@@ -72,7 +72,7 @@ In this tutorial, a simulation ensemble is created and run.
 
 #. Click OK.
 
-   .. _fig.uqt_addnew
+   .. _fig.uqt_addnew:
    .. figure:: ../figs/tutorial/4_AddNewEnsemble2.png
       :alt: Add New Ensemble Dialog, Flowsheet Option
       :name: fig.uqt_addnew
@@ -83,7 +83,7 @@ In this tutorial, a simulation ensemble is created and run.
 
       \centering
 
-   .. _fig.uqt_addnew_emulator
+   .. _fig.uqt_addnew_emulator:
    .. figure:: ../figs/tutorial/4a_AddNewEnsemble2_Emulator.png
       :alt: Add New Ensemble Dialog, Emulator Option
       :name: fig.uqt_addnew_emulator
@@ -110,7 +110,7 @@ In this tutorial, a simulation ensemble is created and run.
    Subsequently, other cells in the row are enabled or disabled
    according to the type selection.
 
-   .. _fig.uqt_sim
+   .. _fig.uqt_sim:
    .. figure:: ../figs/tutorial/5_SimSetup2.png
       :alt: Simulation Ensemble Setup Dialog, Distributions Tab
       :name:
@@ -140,7 +140,7 @@ In this tutorial, a simulation ensemble is created and run.
       simulation ensemble would contain “x6” samples that are randomly
       drawn (with replacement) from the samples in this file.
 
-      .. _fig.uqt_sim_pdfs
+      .. _fig.uqt_sim_pdfs:
       .. figure:: ../figs/tutorial/6_SimSetupPDFs2.png
          :alt: Simulation Ensemble Setup Dialog, Distributions Tab, PDF
          :name: fig.uqt_sim_pdfs
@@ -169,7 +169,7 @@ In this tutorial, a simulation ensemble is created and run.
 #. Once complete, switch to the Sampling Scheme tab
    (Figure :ref:`fig.uqt_sim_samplescheme`).
 
-   .. _fig.uqt_sim_samplescheme
+   .. _fig.uqt_sim_samplescheme:
    .. figure:: ../figs/tutorial/7_SimSetupSampling2.png
       :alt: Simulation Ensemble Setup Dialog, Sampling Scheme Tab
       :name: fig.uqt_sim_samplescheme
@@ -217,7 +217,7 @@ In this tutorial, a simulation ensemble is created and run.
    status of completed runs
    (Figure :ref:`fig.uqt_ensem_added`).
 
-   .. _fig.uqt_ensem_added
+   .. _fig.uqt_ensem_added:
    .. figure:: ../figs/tutorial/8_EnsembleAdded2.png
       :alt: Simulation Ensemble Added
       :name: fig.uqt_ensem_added
@@ -229,7 +229,7 @@ In this tutorial, a simulation ensemble is created and run.
    #. Click Analyze for “Ensemble 1”
       (Figure :ref:`fig.uqt_ensem_complete`).
 
-      .. _fig.uqt_ensem_complete
+      .. _fig.uqt_ensem_complete:
       .. figure:: ../figs/tutorial/9_EnsembleEvalComplete2.png
          :alt: Simulation Ensemble Evaluation Complete
          :name: fig.uqt_ensem_complete
@@ -239,7 +239,7 @@ In this tutorial, a simulation ensemble is created and run.
    #. Step 1 of “Analysis” (bottom page), the user selects Ensemble Data
       (Figure :ref:`fig.uqt_analysis`).
 
-      .. _fig.uqt_analysis
+      .. _fig.uqt_analysis:
       .. figure:: ../figs/tutorial/10_AnalysisDialog2.png
          :alt: Simulation Ensemble Analysis
          :name: fig.uqt_analysis
@@ -254,6 +254,7 @@ In this tutorial, a simulation ensemble is created and run.
       two graphs displaying the probability and cumulative distributions
       plots (Figure :ref:`fig.10a.rosenua`).
 
+   .. _fig.10a.rosenua:
    .. figure:: ../figs/tutorial/10a_RosenbrockUA.png
       :alt: Uncertainty Analysis Results
       :name: fig.10a.rosenua

--- a/docs/source/chapt_uq/tutorial/sim.rst
+++ b/docs/source/chapt_uq/tutorial/sim.rst
@@ -11,7 +11,6 @@ In this tutorial, a simulation ensemble is created and run.
    “Rosenbrock_novectors.foqus" problem (Figure
    :ref:`fig.uqt_home`).
 
-   .. _fig.uqt_home:
    .. figure:: ../figs/tutorial/1_home2.png
       :alt: Home Screen
       :name: fig.uqt_home
@@ -20,10 +19,9 @@ In this tutorial, a simulation ensemble is created and run.
 
 #. Opening this file loads a session that has a flowsheet with one node
    (Figure :ref:`fig.uqt_flowsheet`). See Section
-   :ref:`subsec.opt.tutorial.flowsheet`
+   :ref:`tutorial.simple.flow`
    for a detailed example of creating a flowsheet.
 
-   .. _fig.uqt_flowsheet:
    .. figure:: ../figs/tutorial/2_flowsheet2.png
       :alt: Flowsheet for Rosenbrock Example
       :name: fig.uqt_flowsheet
@@ -33,7 +31,6 @@ In this tutorial, a simulation ensemble is created and run.
 #. Click the **Uncertainty** button (Figure
    :ref:`fig.uqt_uqhome`).
 
-   .. _fig.uqt_uqhome:
    .. figure:: ../figs/tutorial/3_UQScreen2.png
       :alt: Uncertainty Quantification Screen
       :name: fig.uqt_uqhome
@@ -59,7 +56,7 @@ In this tutorial, a simulation ensemble is created and run.
      needs to provide a training data file containing a small simulation
      ensemble generated from the actual simulation model. This training
      data file is be in the PSUADE full file format (Section
-     :ref:`ap:psuadefiles`).
+     `[ap:psuadefiles] <#ap:psuadefiles>`__).
 
    -  Click Browse and select the training data file with which to train
       the response surface. The inputs, outputs and response surface
@@ -72,7 +69,6 @@ In this tutorial, a simulation ensemble is created and run.
 
 #. Click OK.
 
-   .. _fig.uqt_addnew:
    .. figure:: ../figs/tutorial/4_AddNewEnsemble2.png
       :alt: Add New Ensemble Dialog, Flowsheet Option
       :name: fig.uqt_addnew
@@ -83,7 +79,6 @@ In this tutorial, a simulation ensemble is created and run.
 
       \centering
 
-   .. _fig.uqt_addnew_emulator:
    .. figure:: ../figs/tutorial/4a_AddNewEnsemble2_Emulator.png
       :alt: Add New Ensemble Dialog, Emulator Option
       :name: fig.uqt_addnew_emulator
@@ -110,10 +105,9 @@ In this tutorial, a simulation ensemble is created and run.
    Subsequently, other cells in the row are enabled or disabled
    according to the type selection.
 
-   .. _fig.uqt_sim:
    .. figure:: ../figs/tutorial/5_SimSetup2.png
       :alt: Simulation Ensemble Setup Dialog, Distributions Tab
-      :name:
+      :name: fig.uqt_sim
 
       Simulation Ensemble Setup Dialog, Distributions Tab
 
@@ -134,13 +128,12 @@ In this tutorial, a simulation ensemble is created and run.
       non-parametric distribution “Sample” is selected, the user needs
       to specify the name of the sample file (a CSV or PSUADE sample
       format is located in Section
-      :ref:`ap:psuadefiles`) that contains samples for
+      `[ap:psuadefiles] <#ap:psuadefiles>`__) that contains samples for
       the variable “x6.” The user also needs to specify the output index
       to indicate which output in the sample file to use. The resulting
       simulation ensemble would contain “x6” samples that are randomly
       drawn (with replacement) from the samples in this file.
 
-      .. _fig.uqt_sim_pdfs:
       .. figure:: ../figs/tutorial/6_SimSetupPDFs2.png
          :alt: Simulation Ensemble Setup Dialog, Distributions Tab, PDF
          :name: fig.uqt_sim_pdfs
@@ -155,7 +148,7 @@ In this tutorial, a simulation ensemble is created and run.
       (Figure :ref:`fig.uq_sim_loadsample`)
       prompts the user to browse to a PSUADE full file, a PSUADE sample
       file, or CSV file (all formats are described in
-      Section\ :ref:`ap:psuadefiles`) that contains
+      Section\ `[ap:psuadefiles] <#ap:psuadefiles>`__) that contains
       all the samples for all the input variables in the model.
 
    Both of these options offer the user additional flexibility with
@@ -169,7 +162,6 @@ In this tutorial, a simulation ensemble is created and run.
 #. Once complete, switch to the Sampling Scheme tab
    (Figure :ref:`fig.uqt_sim_samplescheme`).
 
-   .. _fig.uqt_sim_samplescheme:
    .. figure:: ../figs/tutorial/7_SimSetupSampling2.png
       :alt: Simulation Ensemble Setup Dialog, Sampling Scheme Tab
       :name: fig.uqt_sim_samplescheme
@@ -217,7 +209,6 @@ In this tutorial, a simulation ensemble is created and run.
    status of completed runs
    (Figure :ref:`fig.uqt_ensem_added`).
 
-   .. _fig.uqt_ensem_added:
    .. figure:: ../figs/tutorial/8_EnsembleAdded2.png
       :alt: Simulation Ensemble Added
       :name: fig.uqt_ensem_added
@@ -229,7 +220,6 @@ In this tutorial, a simulation ensemble is created and run.
    #. Click Analyze for “Ensemble 1”
       (Figure :ref:`fig.uqt_ensem_complete`).
 
-      .. _fig.uqt_ensem_complete:
       .. figure:: ../figs/tutorial/9_EnsembleEvalComplete2.png
          :alt: Simulation Ensemble Evaluation Complete
          :name: fig.uqt_ensem_complete
@@ -239,7 +229,6 @@ In this tutorial, a simulation ensemble is created and run.
    #. Step 1 of “Analysis” (bottom page), the user selects Ensemble Data
       (Figure :ref:`fig.uqt_analysis`).
 
-      .. _fig.uqt_analysis:
       .. figure:: ../figs/tutorial/10_AnalysisDialog2.png
          :alt: Simulation Ensemble Analysis
          :name: fig.uqt_analysis
@@ -254,7 +243,6 @@ In this tutorial, a simulation ensemble is created and run.
       two graphs displaying the probability and cumulative distributions
       plots (Figure :ref:`fig.10a.rosenua`).
 
-   .. _fig.10a.rosenua:
    .. figure:: ../figs/tutorial/10a_RosenbrockUA.png
       :alt: Uncertainty Analysis Results
       :name: fig.10a.rosenua


### PR DESCRIPTION
These warnings will still come up:
docs/source/chapt_sdoe/index.rst:106: WARNING: image file not readable: chapt_sdoe/figs/4_scatterplot_aggregated.png                                                                                                                                                                                       
docs/source/chapt_flowsheet/tutorial/remote.rst:80: WARNING: undefined label: overview.turbine.upload (if the link has no caption the label must precede a section header)
docs/source/chapt_flowsheet/tutorial/sim_flowsheet.rst:64: WARNING: undefined label: chapt.simsinter (if the link has no caption the label must precede a section header)
docs/source/chapt_flowsheet/tutorial/simple_flowsheet.rst:12: WARNING: undefined label: sec.flowsheet.starting.foqus (if the link has no caption the label must precede a section header)
docs/source/chapt_opt/reference/optimization.rst:253: WARNING: undefined label: fig.opt.problem.objective2_code (if the link has no caption the label must precede a section header)
docs/source/chapt_uq/tutorial/sim.rst:144: WARNING: undefined label: fig.uq_sim_loadsample (if the link has no caption the label must precede a section header)
docs/source/chapt_uq/tutorial/sim.rst:186: WARNING: undefined label: session-menu (if the link has no caption the label must precede a section header)