### PR TITLE
Fix plugin search

### DIFF
--- a/foqus_lib/framework/optimizer/BFGS.py
+++ b/foqus_lib/framework/optimizer/BFGS.py
@@ -1,7 +1,7 @@
 """#FOQUS_OPT_PLUGIN BFGS.py
 
 Optimization plugins need to have #FOQUS_OPT_PLUGIN in the first 150 characters,
-have a .py extention and inherit the optimization class.
+have a .py extension and inherit the optimization class.
 
 * FOQUS optimization plugin for scipy BFGS using finite dif
 * Uses scipy optimization module

--- a/foqus_lib/framework/optimizer/NLopt.py
+++ b/foqus_lib/framework/optimizer/NLopt.py
@@ -1,7 +1,7 @@
 """ #FOQUS_OPT_PLUGIN NLopt.py
 
 Optimization plugins need to have #FOQUS_OPT_PLUGIN in the first
-150 characters of text.  They also need to hav a .py extension and
+150 characters of text.  They also need to have a .py extension and
 inherit the optimization class.
 
 * FOQUS optimization plugin for NLopt

--- a/foqus_lib/framework/optimizer/NLopt.py
+++ b/foqus_lib/framework/optimizer/NLopt.py
@@ -1,7 +1,7 @@
 """ #FOQUS_OPT_PLUGIN NLopt.py
 
 Optimization plugins need to have #FOQUS_OPT_PLUGIN in the first
-150 characters of text.  They also need to hav a .py extention and
+150 characters of text.  They also need to hav a .py extension and
 inherit the optimization class.
 
 * FOQUS optimization plugin for NLopt

--- a/foqus_lib/framework/optimizer/OptCMA.py
+++ b/foqus_lib/framework/optimizer/OptCMA.py
@@ -1,6 +1,6 @@
 """ #FOQUS_OPT_PLUGIN  OptCMA.py
  Optimization plugins need to have #FOQUS_OPT_PLUGIN in the first
- 150 characters of text.  They also need to hav a .py extention and
+ 150 characters of text.  They also need to hav a .py extension and
  inherit the optimization class.
 
 * This is an example of an optimization plugin for FOQUS, CMA

--- a/foqus_lib/framework/optimizer/OptCMA.py
+++ b/foqus_lib/framework/optimizer/OptCMA.py
@@ -1,6 +1,6 @@
 """ #FOQUS_OPT_PLUGIN  OptCMA.py
  Optimization plugins need to have #FOQUS_OPT_PLUGIN in the first
- 150 characters of text.  They also need to hav a .py extension and
+ 150 characters of text.  They also need to have a .py extension and
  inherit the optimization class.
 
 * This is an example of an optimization plugin for FOQUS, CMA

--- a/foqus_lib/framework/optimizer/PSUADE.py
+++ b/foqus_lib/framework/optimizer/PSUADE.py
@@ -2,7 +2,7 @@
 #FOQUS_OPT_PLUGIN
 #
 # Optimization plugins need to have FOQUS_OPT_PLUGIN in the first
-# 150 characters of text.  They also need to hav a .py extension and
+# 150 characters of text.  They also need to have a .py extension and
 # inherit the optimization class.
 #
 #

--- a/foqus_lib/framework/optimizer/PSUADE.py
+++ b/foqus_lib/framework/optimizer/PSUADE.py
@@ -2,7 +2,7 @@
 #FOQUS_OPT_PLUGIN
 #
 # Optimization plugins need to have FOQUS_OPT_PLUGIN in the first
-# 150 characters of text.  They also need to hav a .py extention and
+# 150 characters of text.  They also need to hav a .py extension and
 # inherit the optimization class.
 #
 #

--- a/foqus_lib/framework/optimizer/SLSQP.py
+++ b/foqus_lib/framework/optimizer/SLSQP.py
@@ -1,7 +1,7 @@
 """ #FOQUS_OPT_PLUGIN SLSQP.py
 
 Optimization plugins need to have #FOQUS_OPT_PLUGIN in the first
-150 characters of text.  They also need to hav a .py extension and
+150 characters of text.  They also need to have a .py extension and
 inherit the optimization class.
 
 * FOQUS optimization plugin for scipy SLSQP using finite dif

--- a/foqus_lib/framework/optimizer/SLSQP.py
+++ b/foqus_lib/framework/optimizer/SLSQP.py
@@ -1,7 +1,7 @@
 """ #FOQUS_OPT_PLUGIN SLSQP.py
 
 Optimization plugins need to have #FOQUS_OPT_PLUGIN in the first
-150 characters of text.  They also need to hav a .py extention and
+150 characters of text.  They also need to hav a .py extension and
 inherit the optimization class.
 
 * FOQUS optimization plugin for scipy SLSQP using finite dif

--- a/foqus_lib/framework/optimizer/Sample.py
+++ b/foqus_lib/framework/optimizer/Sample.py
@@ -1,7 +1,7 @@
 """ #FOQUS_OPT_PLUGIN Sample.py
 
 Optimization plugins need to have #FOQUS_OPT_PLUGIN in the first
-150 characters of text.  They also need to hav a .py extention and
+150 characters of text.  They also need to hav a .py extension and
 inherit the optimization class.
 
 * Just evaluates the objective function for flowsheet results and

--- a/foqus_lib/framework/optimizer/Sample.py
+++ b/foqus_lib/framework/optimizer/Sample.py
@@ -1,7 +1,7 @@
 """ #FOQUS_OPT_PLUGIN Sample.py
 
 Optimization plugins need to have #FOQUS_OPT_PLUGIN in the first
-150 characters of text.  They also need to hav a .py extension and
+150 characters of text.  They also need to have a .py extension and
 inherit the optimization class.
 
 * Just evaluates the objective function for flowsheet results and

--- a/foqus_lib/framework/plugins/pluginSearch.py
+++ b/foqus_lib/framework/plugins/pluginSearch.py
@@ -19,9 +19,9 @@ import imp
 _log = logging.getLogger("foqus." + __name__)
 
 class plugins():
-    '''
-        This class maintains a list of DFO solver plugins
-    '''
+    """
+    This class maintains a list of DFO solver plugins
+    """
     def __init__(self, idString, pathList, charLimit=200):
         self.idString = idString
         self.pathList = pathList
@@ -40,7 +40,8 @@ class plugins():
                 for fname in pgfiles:
                     mname = fname.rsplit('.', 1) #split off extension
                     if len(mname) > 1 and mname[1] == 'py':
-                        with open(os.path.join(p, fname), 'r') as f:
+                        with open(os.path.join(p, fname), 'r',
+                            encoding="utf-8") as f:
                             try:
                                 l = self.idString in f.read(self.charLimit)
                             except:

--- a/foqus_lib/framework/plugins/pluginSearch.py
+++ b/foqus_lib/framework/plugins/pluginSearch.py
@@ -16,6 +16,8 @@ import importlib
 import logging
 import imp
 
+_log = logging.getLogger("foqus." + __name__)
+
 class plugins():
     '''
         This class maintains a list of DFO solver plugins
@@ -39,14 +41,17 @@ class plugins():
                     mname = fname.rsplit('.', 1) #split off extension
                     if len(mname) > 1 and mname[1] == 'py':
                         with open(os.path.join(p, fname), 'r') as f:
-                            l = self.idString in f.read(self.charLimit)
+                            try:
+                                l = self.idString in f.read(self.charLimit)
+                            except:
+                                _log.exception("error reading py file")
+                                l = False
                         if not l:
                             continue
                         try:
                             if mname[0] in self.plugins:
-                                logging.getLogger("foqus." + __name__).\
-                                    info("Reloading Plugin: " + \
-                                    os.path.join(p, fname))
+                                _log.info("Reloading Plugin: {}".format(
+                                    os.path.join(p, fname)))
                                 self.plugins[mname[0]] = \
                                     imp.reload(self.plugins[mname[0]])
                             else:
@@ -56,9 +61,8 @@ class plugins():
                                 self.plugins[mname[0]] = \
                                     importlib.import_module(mname[0])
                         except:
-                            logging.getLogger("foqus." + __name__).\
-                                exception("Error Loading Plugin: " + \
-                                os.path.join(p, fname))
+                            _log.exception("Error Loading Plugin: {}".format(
+                                os.path.join(p, fname)))
         # Now check that the plugins have what they need to be used
         for pkey, p in list(self.plugins.items()):
             try:
@@ -67,5 +71,4 @@ class plugins():
                 av = False
             if not av:
                 del self.plugins[pkey]
-                logging.getLogger("foqus." + __name__).info(
-                    "Removing plugin, due to missing dependency: "+pkey)
+                _log.info("Removing plugin, due to missing dependency: " + pkey)

--- a/foqus_lib/framework/surrogate/ACOSSO.py
+++ b/foqus_lib/framework/surrogate/ACOSSO.py
@@ -1,8 +1,8 @@
 """ #FOQUS_SURROGATE_PLUGIN ACOSSO.py
 
-Surrogate plugins need to have FOQUS_SURROGATE_PLUGIN in the first
-150 characters of text.  They also need to hav a .py extention and
-inherit the surrogate class.
+Surrogate plugins need to have FOQUS_SURROGATE_PLUGIN in the first 150
+characters of text.  They also need to hav a .py extention and inherit the
+surrogate class.
 
 * Plugin wprapper for the ACOSSO surrogate model builer.
 * ACOSSO is excuted in R and a working R install with the quadprog
@@ -31,11 +31,11 @@ from foqus_lib.framework.listen import listen
 from multiprocessing.connection import Client
 
 def checkAvailable():
-    '''
-        Plug-ins should have this function to check availability of any
-        additional required software.  If requirements are not available
-        plug-in will not be available.
-    '''
+    """
+    Plug-ins should have this function to check availability of any
+    additional required software.  If requirements are not available
+    plug-in will not be available.
+    """
     # Need to check for R and quadprog?
     return True
 

--- a/foqus_lib/framework/surrogate/ACOSSO.py
+++ b/foqus_lib/framework/surrogate/ACOSSO.py
@@ -1,7 +1,7 @@
 """ #FOQUS_SURROGATE_PLUGIN ACOSSO.py
 
 Surrogate plugins need to have FOQUS_SURROGATE_PLUGIN in the first 150
-characters of text.  They also need to hav a .py extention and inherit the
+characters of text.  They also need to hav a .py extension and inherit the
 surrogate class.
 
 * Plugin wprapper for the ACOSSO surrogate model builer.

--- a/foqus_lib/framework/surrogate/ACOSSO.py
+++ b/foqus_lib/framework/surrogate/ACOSSO.py
@@ -1,7 +1,7 @@
 """ #FOQUS_SURROGATE_PLUGIN ACOSSO.py
 
 Surrogate plugins need to have FOQUS_SURROGATE_PLUGIN in the first 150
-characters of text.  They also need to hav a .py extension and inherit the
+characters of text.  They also need to have a .py extension and inherit the
 surrogate class.
 
 * Plugin wprapper for the ACOSSO surrogate model builer.

--- a/foqus_lib/framework/surrogate/ALAMO.py
+++ b/foqus_lib/framework/surrogate/ALAMO.py
@@ -1,7 +1,7 @@
 """ #FOQUS_SURROGATE_PLUGIN ALAMO.py
 
 Surrogate plugins need to have FOQUS_SURROGATE_PLUGIN in the first
-150 characters of text.  They also need to hav a .py extension and
+150 characters of text.  They also need to have a .py extension and
 inherit the surrogate class.
 
 * This is an example of a surrogate model builder plugin for FOQUS,

--- a/foqus_lib/framework/surrogate/ALAMO.py
+++ b/foqus_lib/framework/surrogate/ALAMO.py
@@ -1,7 +1,7 @@
 """ #FOQUS_SURROGATE_PLUGIN ALAMO.py
 
 Surrogate plugins need to have FOQUS_SURROGATE_PLUGIN in the first
-150 characters of text.  They also need to hav a .py extention and
+150 characters of text.  They also need to hav a .py extension and
 inherit the surrogate class.
 
 * This is an example of a surrogate model builder plugin for FOQUS,

--- a/foqus_lib/framework/surrogate/BSS-ANOVA.py
+++ b/foqus_lib/framework/surrogate/BSS-ANOVA.py
@@ -1,7 +1,7 @@
 """ #FOQUS_SURROGATE_PLUGIN BSS-ANOVA.py
 
 Surrogate plugins need to have FOQUS_SURROGATE_PLUGIN in the first
-150 characters of text.  They also need to have a .py extention and
+150 characters of text.  They also need to have a .py extension and
 inherit the surrogate class.
 
 * Plugin wrapper for the BSS-ANOVA surrogate model builer.


### PR DESCRIPTION
This fixes issue #462 

Added try/except and logging for finding future problems.   The problem was a 0x90 in ACOSSO.py.  I don't know how it got there, but I changed the plugin search code to read the files with UTF-8 encoding.  That fixed it.  That character must have gotten in recently somehow.