### PR TITLE
Fix double layout for filterFrame.

### DIFF
--- a/foqus_lib/gui/uq/uqSetupFrame.py
+++ b/foqus_lib/gui/uq/uqSetupFrame.py
@@ -359,7 +359,7 @@ background: qlineargradient(spread:pad, x1: 0, y1: 0.5, x2: 1, y2: 0.5, stop: 0 
         LocalExecutionModule.session = dat
         self.filterWidget = uqDataBrowserFrame(self)
         self.filterWidget.indicesSelectedSignal.connect(self.createFilteredEnsemble)
-        self.filterFrame.setLayout(QStackedLayout(self.filterFrame))
+        #self.filterFrame.setLayout(QStackedLayout(self.filterFrame))
         self.filterFrame.layout().addWidget(self.filterWidget)
 
         ###### Set up simulation ensembles section


### PR DESCRIPTION
I made a change to avoid having two layouts in filterFrame, which causes an error.  FOQUS usually ignores this and works anyway, but it still produces an error message and messes up the appveyor testing.

A quick test seems to show this working fine, but UQ isn't my area, so @sotorrio1, can you take a closer look and make sure this is okay.  The layout must already be in the ui file, so I guess the commented line is redundant. 