### PR TITLE
Add AppVeyor badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Documentation Status](https://readthedocs.org/projects/foqus/badge/?version=latest)](https://foqus.readthedocs.io/en/latest/?badge=latest)
+[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/0tol930ch5k887fg?svg=true)](https://ci.appveyor.com/project/perrenyang/foqus-37w98)
 
 # FOQUS: Framework for Optimization, Quantification of Uncertainty, and Surrogates
 Package includes: FOQUS GUI, Optimization Engine, Turbine Client. *Requires access to a Turbine Gateway installation either locally or on a separate cluster/server. #GAMS is required for heat integration option.*


### PR DESCRIPTION
Note: the AppVeyor project is currently sitting in my account, but we should be able to export it to someone else to maintain more permanently. At that point, the badge URL should be updated.