### PR TITLE
ALAMO Adaptive sampling fix.

### DIFF
--- a/foqus_lib/framework/surrogate/ALAMO.py
+++ b/foqus_lib/framework/surrogate/ALAMO.py
@@ -471,6 +471,14 @@ class surrogateMethod(surrogate):
             This function overloads the Thread class function,
             and is called when you run start() to start a new thread.
         '''
+        alamoExe = self.dat.foqusSettings.alamo_path
+        try:
+            assert(os.path.isfile(alamoExe))
+        except AssertionError:
+            msg = "The ALAMO executable was not found. Check the ALAMO exec "\
+                  "path in settings and that ALAMO is installed."
+            self.msgQueue.put(msg)
+            raise AssertionError(msg)
         try:
             #Setup dictionaries to convert between foqus and ALAMO
             #variable names.  Also setup a list of input and output
@@ -495,14 +503,9 @@ class surrogateMethod(surrogate):
             alamoDirFull = os.path.abspath(alamoDir)
             self.setupWorkingDir()
             adpexe = os.path.join(alamoDirFull, 'foqusALAMOClient.py')
-            if os.path.isfile(adpexe):
-                adpexe = win32api.GetShortPathName(adpexe)
-                self.writeAlamoInputFile(adaptiveExe=adpexe)
-            else:
-                self.writeAlamoInputFile(adaptiveExe=adpexe)
+            self.writeAlamoInputFile(adaptiveExe=adpexe)
             if self.checkNumVars():
                 return
-            alamoExe = self.dat.foqusSettings.alamo_path
             alamoInput = self.options["Input File"].value
             alamoOutput = alamoInput.rsplit('.', 1)[0] + '.lst'
             self.msgQueue.put("------------------------------------")
@@ -569,10 +572,23 @@ class surrogateMethod(surrogate):
                     "Exception in ALAMO Thread",
                     exc_info=sys.exc_info())
 
-    def writeAlamoInputFile(self, adaptiveExe="foqusALAMOClient.py"):
-        '''
-            Write the input file for the ALAMO executable
-        '''
+    def writeAlamoInputFile(self, adaptiveExe="foqusALAMOClient.py", ):
+        """Write the input file for the ALAMO executable."""
+        # Get around the need to associate py files with a python
+        # interperater in Windows.
+        adaptive = self.samplers.get(self.options['SAMPLER'].value, False)
+        if os.name == "nt":
+            if adaptive:
+                with open(adaptiveExe + ".bat", "w") as f:
+                    f.write("python {} %*".format(adaptiveExe))
+                adaptiveExe += ".bat"
+            # On Windows, need to use short file names for ALAMO 
+            adaptiveExe = win32api.GetShortPathName(adaptiveExe)
+        if not adaptive:
+            maxiter = 1
+            adaptive = 1
+        else:
+            maxiter = self.options["MAXITER"].value
         #Number f input and output variables
         nin = self.nInput()
         nout = self.nOutput()
@@ -589,12 +605,6 @@ class surrogateMethod(surrogate):
         #Get some option values
         nsample = self.options['NSAMPLE'].value
         maxsim = self.options['MAXSIM'].value
-        adaptive = self.samplers.get(self.options['SAMPLER'].value, 0)
-        if adaptive == 0:
-            maxiter = 1
-            adaptive = 1
-        else:
-            maxiter = self.options["MAXITER"].value
         modeler = self.modelers.get(self.options['MODELER'].value, 1)
         preset = self.options['PRESET'].value
         maxtime = self.options['MAXTIME'].value
@@ -686,7 +696,7 @@ class surrogateMethod(surrogate):
             af.write("sampler {0}\n".format(adaptive))
             af.write("maxiter {0}\n".format(maxiter))
             af.write("maxsim {0}\n".format(maxsim))
-            af.write("simulator {} {}\n".format("python", adaptiveExe))
+            af.write("simulator {}\n".format(adaptiveExe))
             af.write('#simin input.txt\n')
             af.write('#simout output.txt\n')
             af.write("ninputs {0}\n".format(nin))

--- a/foqus_lib/framework/surrogate/ALAMO.py
+++ b/foqus_lib/framework/surrogate/ALAMO.py
@@ -686,7 +686,7 @@ class surrogateMethod(surrogate):
             af.write("sampler {0}\n".format(adaptive))
             af.write("maxiter {0}\n".format(maxiter))
             af.write("maxsim {0}\n".format(maxsim))
-            af.write("simulator {0}\n".format(adaptiveExe))
+            af.write("simulator {} {}\n".format("python", adaptiveExe))
             af.write('#simin input.txt\n')
             af.write('#simout output.txt\n')
             af.write("ninputs {0}\n".format(nin))

--- a/foqus_lib/framework/surrogate/foqusALAMOClient.py
+++ b/foqus_lib/framework/surrogate/foqusALAMOClient.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """foqusALAMOClient.py
 
 * The purpose of this scrip is to be the simulator executable for

--- a/foqus_lib/gui/surrogate/surrogateFrame.py
+++ b/foqus_lib/gui/surrogate/surrogateFrame.py
@@ -46,6 +46,7 @@ class surrogateFrame(_surrogateFrame, _surrogateFrameUI):
         self.toolSelectBox.addItems(self.tools)
         self.createOptionsTables()
         self.toolSelectBox.currentIndexChanged.connect(self.selectTool)
+        self.toolBox.setCurrentIndex(1)
         self.dataBrowser = dataBrowserFrame(
             dat, self.toolBox.currentWidget())
         self.dataBrowser.editFiltersButton.clicked.connect(
@@ -75,6 +76,7 @@ class surrogateFrame(_surrogateFrame, _surrogateFrameUI):
             self.selectTool(0)
         except:
             pass
+        self.toolBox.setCurrentIndex(0)
 
     def selectAllInputs(self):
         table = self.inputTable
@@ -112,7 +114,7 @@ class surrogateFrame(_surrogateFrame, _surrogateFrameUI):
         '''
         self.monitorTextBox.setPlainText("")
         self.applyChanges()
-        self.toolBox.setCurrentIndex(3)
+        self.toolBox.setCurrentIndex(4)
         if self.dat.surrogateProblem == None: return
         tool = self.toolSelectBox.currentText()
         pg = self.dat.surrogateMethods.plugins[tool].\

--- a/foqus_lib/gui/surrogate/surrogateFrame_UI.ui
+++ b/foqus_lib/gui/surrogate/surrogateFrame_UI.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>979</width>
-    <height>858</height>
+    <width>1516</width>
+    <height>1207</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -107,28 +107,20 @@
     </layout>
    </item>
    <item>
-    <widget class="QGroupBox" name="groupBox">
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>120</height>
-      </size>
-     </property>
-     <property name="title">
-      <string>Method Description</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <item>
-       <widget class="QTextBrowser" name="methodDescriptionBox"/>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
     <widget class="QTabWidget" name="toolBox">
      <property name="currentIndex">
       <number>0</number>
      </property>
+     <widget class="QWidget" name="tab_5">
+      <attribute name="title">
+       <string>Method Description</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_7">
+       <item>
+        <widget class="QTextBrowser" name="methodDescriptionBox"/>
+       </item>
+      </layout>
+     </widget>
      <widget class="QWidget" name="tab">
       <attribute name="title">
        <string>Data</string>


### PR DESCRIPTION
This relates to issue #482.  I don't think we should ask users to mess with the registry or file associations in Windows.  So I came up with a solution that is not great, but at least doesn't require any crazy setup.  This is that same situation faced by @sotorrio1 for the py file called by psuade.  I just spit out a bat script that contains "python wathever\path\whatever.py %*".  This will just use the python in the environment to run the script.  No registry modification needed.  Unless anyone has a better solution, I suggest the same for the psuade counter part, and we try to keep the install simple.  In this case the the bat is needed because ALAMO expects a single file to execute and doesn't understand "python path\to\file.py"

The other change in this is to give you an error that you can understand if the ALAMO isn't installed or the path isn't set right.  