### PR TITLE
Fixing link for copyright.rst file

### DIFF
--- a/docs/source/copyright.rst
+++ b/docs/source/copyright.rst
@@ -1,4 +1,1 @@
-Copyright
-=========
-
 ../../LICENSE.md


### PR DESCRIPTION
This is just fixing the link for the copyright.rst file.  Hopefully this will still work on Windows...