### PR TITLE
Adding pytest & coverage via CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,55 @@
+# Python CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-python/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
+      - image: circleci/python:3.6.1
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "requirements.txt" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run:
+          name: install dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install -r requirements.txt
+
+      - save_cache:
+          paths:
+            - ./venv
+          key: v1-dependencies-{{ checksum "requirements.txt" }}
+
+      # run tests!
+      # this example uses Django's built-in test-runner
+      # other common Python testing frameworks include pytest and nose
+      # https://pytest.org
+      # https://nose.readthedocs.io
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            python manage.py test
+
+      - store_artifacts:
+          path: test-reports
+          destination: test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,22 +40,22 @@ jobs:
           key: v1-dependencies-{{ checksum "requirements.txt" }}
       
       - run:
-        name: Install FOQUS
-        command: |
-          python3 setup.py -q install
+          name: Install FOQUS
+          command: |
+            python3 setup.py -q install
 
       - run:
-        name: Setup testing env
-        command: |
-          pip install -q pytest
-          pip install -q coverage
+          name: Setup testing env
+          command: |
+            pip install -q pytest
+            pip install -q coverage
 
       - run:
-        name: Run Tests
-        command: |
-          coverage run -m pytest
-          coverage report
-          coverage html  # Generate html report
+          name: Run Tests
+          command: |
+            coverage run -m pytest
+            coverage report
+            coverage html  # Generate html report
 
       - store_artifacts:
           path: htmlcov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,17 +42,20 @@ jobs:
       - run:
           name: Install FOQUS
           command: |
+            . venv/bin/activate
             python3 setup.py -q install
 
       - run:
           name: Setup testing env
           command: |
+            . venv/bin/activate
             pip install -q pytest
             pip install -q coverage
 
       - run:
           name: Run Tests
           command: |
+            . venv/bin/activate
             coverage run -m pytest
             coverage report
             coverage html  # Generate html report

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
           command: |
             . venv/bin/activate
             coverage run -m pytest
-            coverage report --include=foqus_lib/*
+            coverage report --omit=*site-packages*
             coverage html  # Generate html report
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,32 +28,34 @@ jobs:
             - v1-dependencies-
 
       - run:
-          name: install dependencies
+          name: requirements
           command: |
             python3 -m venv venv
             . venv/bin/activate
             pip install -qr requirements.txt
-            pip install pytest
-            python3 setup.py -q install
 
       - save_cache:
           paths:
             - ./venv
           key: v1-dependencies-{{ checksum "requirements.txt" }}
-
-      # run tests!
-      # this example uses Django's built-in test-runner
-      # other common Python testing frameworks include pytest and nose
-      # https://pytest.org
-      # https://nose.readthedocs.io
+      
       - run:
-          name: run tests
-          command: |
-            . venv/bin/activate
-            pytest
-            mkdir gui_testing
-            foqus.py -s test/system_test/ui_test_01.py --working_dir gui_testing
+        name: Install FOQUS
+        command: |
+          python3 setup.py -q install
+
+      - run:
+        name: Setup testing env
+        command: |
+          pip install -q pytest
+          pip install -q coverage
+
+      - run:
+        name: Run Tests
+        command: |
+          coverage run -m pytest
+          coverage report
+          coverage html  # Generate html report
 
       - store_artifacts:
-          path: test-reports
-          destination: test-reports
+          path: htmlcov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
-      - image: circleci/python:3.6.1
+      - image: circleci/python:3.7.4
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -28,7 +28,7 @@ jobs:
             - v1-dependencies-
 
       - run:
-          name: requirements
+          name: Install Requirements
           command: |
             python3 -m venv venv
             . venv/bin/activate
@@ -46,7 +46,7 @@ jobs:
             python3 setup.py -q install
 
       - run:
-          name: Setup testing env
+          name: Setup Testing Environment
           command: |
             . venv/bin/activate
             pip install -q pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,8 +56,8 @@ jobs:
           name: Run Tests
           command: |
             . venv/bin/activate
-            coverage run -m pytest foqus_lib
-            coverage report
+            coverage run -m pytest
+            coverage report --include=foqus_lib/*
             coverage html  # Generate html report
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
           command: |
             . venv/bin/activate
             coverage run -m pytest
-            coverage report
+            coverage report --omit=*site-packages*
             coverage html --omit=*site-packages*  # Generate html report
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,8 +57,8 @@ jobs:
           command: |
             . venv/bin/activate
             coverage run -m pytest
-            coverage report --omit=*site-packages*
-            coverage html  # Generate html report
+            coverage report
+            coverage html --omit=*site-packages*  # Generate html report
 
       - store_artifacts:
           path: htmlcov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
           name: Run Tests
           command: |
             . venv/bin/activate
-            coverage run -m pytest
+            coverage run -m pytest foqus_lib
             coverage report
             coverage html  # Generate html report
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,8 @@ jobs:
           command: |
             . venv/bin/activate
             pytest
+            mkdir gui_testing
+            foqus.py -s test/system_test/ui_test_01.py --working_dir gui_testing
 
       - store_artifacts:
           path: test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,15 +49,20 @@ jobs:
           name: Setup Testing Environment
           command: |
             . venv/bin/activate
-            pip install -q pytest
-            pip install -q coverage
+            pip install -q pytest coverage pylint
+
+      - run:
+          name: Run PyLint
+          command: |
+            . venv/bin/activate
+            pylint -E foqus_lib --extension-pkg-whitelist=PyQt5 --ignored-modules=win32process,win32api,adodbapi || true
 
       - run:
           name: Run Tests
           command: |
             . venv/bin/activate
             coverage run -m pytest
-            coverage report --omit=*site-packages*
+            coverage report --omit=*site-packages* --fail-under=22
             coverage html --omit=*site-packages*  # Generate html report
 
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,9 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install -r requirements.txt
+            pip install -qr requirements.txt
+            pip install pytest
+            python3 setup.py -q install
 
       - save_cache:
           paths:
@@ -48,7 +50,7 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
-            python manage.py test
+            pytest
 
       - store_artifacts:
           path: test-reports

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Documentation Status](https://readthedocs.org/projects/foqus/badge/?version=latest)](https://foqus.readthedocs.io/en/latest/?badge=latest)
-[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/0tol930ch5k887fg?svg=true)](https://ci.appveyor.com/project/perrenyang/foqus-37w98)
+[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/g0gvhmlwsv4a4y63?svg=true)](https://ci.appveyor.com/project/ksbeattie/foqus)
+[![CircleCI Build Status](https://circleci.com/gh/CCSI-Toolset/FOQUS.svg?style=svg)](https://circleci.com/gh/CCSI-Toolset/FOQUS)
 
 # FOQUS: Framework for Optimization, Quantification of Uncertainty, and Surrogates
 Package includes: FOQUS GUI, Optimization Engine, Turbine Client. *Requires access to a Turbine Gateway installation either locally or on a separate cluster/server. #GAMS is required for heat integration option.*


### PR DESCRIPTION
I thought there was an issue about getting tests going again, but it appears there isn't one.

This should add a very simple but working "proof-of-concept" of CircleCI running pytest and generating a coverage report.