### PR TITLE
Fix doc warnings in sim_flowsheet.rst

### DIFF
--- a/docs/source/chapt_flowsheet/tutorial/sim_flowsheet.rst
+++ b/docs/source/chapt_flowsheet/tutorial/sim_flowsheet.rst
@@ -116,7 +116,7 @@ the steps to draw the flowsheet.
 
 18. Click **Toggle Node Editor**. The Node Editor displays as
     illustrated in Figure
-    :ref:`fig.tut.opt.nodeEditor`.
+    :ref:`fig.tut.opt.nodeEditor_upd`.
 
 .. figure:: ../figs/flowsheetDraw.svg
    :alt: Flowsheet Editor
@@ -127,7 +127,7 @@ the steps to draw the flowsheet.
 Each node must be assigned the appropriate simulation. Use the Node
 Editor to set the simulation type and the simulation name from
 simulation uploaded to Turbine. The Node Editor is illustrated in Figure
-:ref:`fig.tut.opt.nodeEditor`
+:ref:`fig.tut.opt.nodeEditor_upd`
 
 19. Under **Model** and **Type**, set the simulation **Type** to
     Turbine. This indicates that the simulation is to be run with

--- a/docs/source/chapt_flowsheet/tutorial/sim_flowsheet.rst
+++ b/docs/source/chapt_flowsheet/tutorial/sim_flowsheet.rst
@@ -49,14 +49,13 @@ copy the example files to a convenient location.
 
    Session Description
 
-[subsec.opt.tutorial.flowsheet] There are two models needed for this
-optimization problem: (1) the ACM model for the BFB capture system and
-(2) the Excel cost estimating spreadsheet. These models are provided in
-the example files directory, under optimization/models (see Section
-:ref:`tutorial.example.files`). There are two
-SimSinter configuration files: (1) BFB_sinter_config_v6.2.json for the
-process model and (2) BFB_cost_v6.2.3.json for the cost model. The next
-step is to upload the models to Turbine.
+There are two models needed for this optimization problem: (1) the ACM model for
+the BFB capture system and (2) the Excel cost estimating spreadsheet. These
+models are provided in the example files directory, under optimization/models
+(see Section :ref:`tutorial.example.files`). There are two SimSinter
+configuration files: (1) BFB_sinter_config_v6.2.json for the process model
+and (2) BFB_cost_v6.2.3.json for the cost model. The next step is to upload the
+models to Turbine.
 
 6.  Open the **Add\Update Model to Turbine** dialog box (Figure
     :ref:`fig.tut.opt.menu.upload`).


### PR DESCRIPTION
The following warnings come up when generating the docs:
```
/home/ksb/Projects/CCSI/github/ksbeattie/FOQUS/docs/source/chapt_flowsheet/tutorial/sim_flowsheet.rst:117: WARNING: undefined label: fig.tut.opt.nodeeditor (if the link has no caption the label must precede a section header)
/home/ksb/Projects/CCSI/github/ksbeattie/FOQUS/docs/source/chapt_flowsheet/tutorial/sim_flowsheet.rst:127: WARNING: undefined label: fig.tut.opt.nodeeditor (if the link has no caption the label must precede a section header)
```
This is an attempt to fix them, but I'm not 100% I've done it correctly.

While doing this I noticed another problem at line 52 of sim_flowsheet.rst:  Should it start with a `[subsec.opt.tutorial.flowsheet]`?
