### PR TITLE
Fixing reference in alamo tutorial

### DIFF
--- a/docs/source/chapt_surrogates/tutorial/alamo.rst
+++ b/docs/source/chapt_surrogates/tutorial/alamo.rst
@@ -181,7 +181,7 @@ single test run from the UQ samples.
 
    Surrogate Data
 
-27. Figure :ref:`fig.tut.sur.dataFilter`
+27. Figure :ref:`fig.tut.sur.dataFilter_surrogate_upd`
     displays the Data Filter Editor.
 
 28. Add the filter for initial data.


### PR DESCRIPTION
When generating the docs, I'm seeing the following warning:

    /home/ksb/Projects/CCSI/github/ksbeattie/FOQUS/docs/source/chapt_surrogates/tutorial/alamo.rst:184: WARNING: undefined label: fig.tut.sur.datafilter (if the link has no caption the label must precede a section header)

I think this fixes it, but I'm not entirely sure.