### PR TITLE
Fixing sip to latest version compatable with PyQt5 5.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyQt5==5.9
-sip
+sip==4.19.8
 sphinx
 sphinx_rtd_theme
 matplotlib


### PR DESCRIPTION
The automated tests were failing because a new version of `sip` was released that is incompatible with PyQt5 5.9.

This message came when running `pip install -r requirements.txt`:

    ERROR: pyqt5 5.9 has requirement sip<4.20,>=4.19.3, but you'll have sip 5.0.0 which is incompatible.

This patch fixes the version of `sip` to `4.19.8` (the most recent with a pypi package) yet less than `5.0`

Now, I'm not entirely sure this is the correct version of sip to use.  https://www.riverbankcomputing.com/software/sip/download seems to suggest that the package `PyQt5-sip` should be used, which when I checked brings in version `12.7.0` which seems entirely different.

Any ideas on which version of `sip` we should be using?