### PR TITLE
Fixing cases in unit_test so pylint -E passes

### DIFF
--- a/foqus_lib/unit_test/massBalanceTest.py
+++ b/foqus_lib/unit_test/massBalanceTest.py
@@ -8,7 +8,7 @@ import os
 
 class testMassBalance(unittest.TestCase):
     def loadGraph(self, fname):
-        gr = graph()
+        gr = Graph()
         testfile = os.path.join(
             os.path.dirname(__file__), 
             fname)

--- a/foqus_lib/unit_test/nodeVarListTest.py
+++ b/foqus_lib/unit_test/nodeVarListTest.py
@@ -7,7 +7,7 @@ import json
 
 class testNodeVarListSteady(unittest.TestCase):
     def makeTestList1(self):
-        l = nodeVarList()
+        l = NodeVarList()
         l.addNode("N1")
         l.addNode("N2")
         l.addVariable(
@@ -37,7 +37,7 @@ class testNodeVarListSteady(unittest.TestCase):
         return l
 
     def makeTestList2(self):
-        l = nodeVarList()
+        l = NodeVarList()
         l.addNode("N1")
         l.addVariable(
             "N1",

--- a/foqus_lib/unit_test/nodeVarsTest.py
+++ b/foqus_lib/unit_test/nodeVarsTest.py
@@ -56,7 +56,7 @@ class testNodeVarsSteady(unittest.TestCase):
 
     def testSetTimeStepOutOfBounds(self):
         var = self.makeVar()
-        with self.assertRaises(nodeVarEx) as cm:
+        with self.assertRaises(NodeVarEx) as cm:
             var.setTimeStep(2)
         e = cm.exception
         self.assertEqual(e.code, 22)
@@ -72,7 +72,7 @@ class testNodeVarsSteady(unittest.TestCase):
         # time step, and there is no second to last time step in
         # this case
         var = self.makeVar()
-        with self.assertRaises(nodeVarEx) as cm:
+        with self.assertRaises(NodeVarEx) as cm:
             var.setTimeStep(-2)
         e = cm.exception
         self.assertEqual(e.code, 22)
@@ -129,7 +129,7 @@ class testNodeVarsSteady(unittest.TestCase):
         # shape, should raise an exception
         var = self.makeVar()
         var.setShape((2,2))
-        with self.assertRaises(nodeVarEx) as cm:
+        with self.assertRaises(NodeVarEx) as cm:
             var.value = [[2.1, 2.2], [2.3]]
         e = cm.exception
         self.assertEqual(e.code, 0)


### PR DESCRIPTION
First step for #600 

I've changed the cases of a few classes so that `pylint -E foqus_lib/unit_test` passes.
