### PR TITLE
pylint errors in at_dict: bad super() call

### DIFF
--- a/foqus_lib/framework/at_dict/at_dict.py
+++ b/foqus_lib/framework/at_dict/at_dict.py
@@ -1,29 +1,30 @@
 
 class AtDict(dict):
     def __getattr__(self, name):
-            return self[name]
+        return self[name]
 
     def __setattr__(self, name, value):
         if name in list(self.keys()):
             self[name] = value
         else:
-             super(AtDict, self).__setattr__(name, value)
+            super().__setattr__(name, value)
+
 
 class OrderedAtDict(AtDict):
     def __init__(self, *args, **kwargs):
         self._ordered_keys = []
-        super(AtDict, self).__init__(self, *args, **kwargs)
+        super().__init__(self, *args, **kwargs)
 
     def __setitem__(self, name, value):
         if name not in self._ordered_keys:
             self._ordered_keys.append(name)
-        super(AtDict, self).__setitem__(name, value)
+        super().__setitem__(name, value)
 
     def __delitem__(self, name):
         if name not in self._ordered_keys:
             return
         self._ordered_keys.remove(name)
-        super(AtDict, self).__delitem__(name)
+        super().__delitem__(name)
 
     def __iter__(self):
         for k in self._ordered_keys:


### PR DESCRIPTION
Addresses #600
```
************* Module foqus_lib.framework.at_dict.at_dict
foqus_lib/framework/at_dict/at_dict.py:15:8: E1003: Bad first argument 'AtDict' given to super() (bad-super-call)
foqus_lib/framework/at_dict/at_dict.py:20:8: E1003: Bad first argument 'AtDict' given to super() (bad-super-call)
foqus_lib/framework/at_dict/at_dict.py:26:8: E1003: Bad first argument 'AtDict' given to super() (bad-super-call)
```
Fixed based on python 3 suggestion here:
https://docs.quantifiedcode.com/python-anti-patterns/correctness/bad_first_argument_given_to_super.html
