### PR TITLE
missing "self" in func defn

### DIFF
--- a/foqus_lib/framework/foqusException/foqusException.py
+++ b/foqus_lib/framework/foqusException/foqusException.py
@@ -41,7 +41,7 @@ class foqusException(Exception):
         return self.codeString.get(self.code,
                                 "Error code: {0}".format(self.code))
 
-    def setCodeStrings():
+    def setCodeStrings(self):
         '''
             This is a function that should be overloaded to add to the
             error code strings to the codeString dictionary, use integer


### PR DESCRIPTION
pylint discovery, addresses #600 

```
************* Module foqus_lib.framework.foqusException.foqusException
foqus_lib/framework/foqusException/foqusException.py:35:8: E1121: Too many positional arguments for method call (too-many-function-args)
foqus_lib/framework/foqusException/foqusException.py:44:4: E0211: Method has no argument (no-method-argument)
```

Looks like a missing `self`.
