### PR TITLE
Pylint errors in framework/graph/

### DIFF
--- a/foqus_lib/framework/graph/OptGraphOptim.py
+++ b/foqus_lib/framework/graph/OptGraphOptim.py
@@ -82,7 +82,6 @@ class optim:
         res = []
         const = []
         x = self.x
-        f = self.f
         for o in self.g:
             vi = eval(o.pycode)
             const.append(vi)
@@ -128,7 +127,6 @@ class optim:
             return [1, "Optimization method requires at least " + str(minVars)]
         # Check Objective expressions
         x = self.x
-        f = self.f
         if len(self.obj) < 1:
             return [
                 1,

--- a/foqus_lib/framework/graph/graph.py
+++ b/foqus_lib/framework/graph/graph.py
@@ -1347,7 +1347,7 @@ class Graph(threading.Thread):
         # Check if new name is in use
         # if it is don't rename
         if newName in list(self.nodes.keys()):
-            raise
+            raise (f"Can't rename to {newName}, name already in use.")
         # search edges and change names
         for edge in self.edges:
             if edge.start == oldName:

--- a/foqus_lib/framework/graph/heatIntegration.py
+++ b/foqus_lib/framework/graph/heatIntegration.py
@@ -7,48 +7,48 @@ def makeHeatIntegrationNode(node):
     #should only need to be called once after that everything gets saved
     #
     # Input variables
-    node.inVars["Hrat"] = gn.nodeVars(
+    node.inVars["Hrat"] = gn.NodeVars(
             value = 10.0,
             vmax  = 500.0,
             vdflt = 10.0,
             unit  = "K",
             vdesc = "Minimum approach temperature",
             vst   = "sinter")
-    node.inVars["Max.Time"] = gn.nodeVars(
+    node.inVars["Max.Time"] = gn.NodeVars(
             value = 60.0,
             vmax  = 10000.0,
             vdflt = 60.0,
             unit  = "second",
             vdesc = "Maximum allowable time for heat integration",
             vst   = "sinter")
-    node.inVars["Net.Power"] = gn.nodeVars(
+    node.inVars["Net.Power"] = gn.NodeVars(
             value = None,
             vmax  = 1000.0,
             unit  = "MW",
             vdesc = "Net power output without CCS",
             vst   = "sinter")
     # Output variables
-    node.outVars["Utility.Cost"] = gn.nodeVars(
+    node.outVars["Utility.Cost"] = gn.NodeVars(
             unit  = "$/hr",
             vdesc = "Total utility cost",
             vst   = "sinter")
-    node.outVars["HP_Steam.Consumption"] = gn.nodeVars(
+    node.outVars["HP_Steam.Consumption"] = gn.NodeVars(
             unit  = "GJ/hr",
             vdesc = "High-pressure steam (230 C) consumption (Cost: $8.04/GJ)",
             vst   = "sinter")
-    node.outVars["MP_Steam.Consumption"] = gn.nodeVars(
+    node.outVars["MP_Steam.Consumption"] = gn.NodeVars(
             unit  = "GJ/hr",
             vdesc = "Medium-pressure steam (164 C) consumption (Cost: $6.25/GJ)",
             vst   = "sinter")
-    node.outVars["Cooling_Water.Consumption"] = gn.nodeVars(
+    node.outVars["Cooling_Water.Consumption"] = gn.NodeVars(
             unit = "GJ/hr",
             vdesc = "Cooling water (20 C) consumption (Cost: $0.21/GJ)",
             vst   = "sinter")
-    node.outVars["FH.Heat.Addition"] = gn.nodeVars(
+    node.outVars["FH.Heat.Addition"] = gn.NodeVars(
             unit = "GJ/hr",
             vdesc = "Heat addition to feed water heaters",
             vst   = "sinter")
-    node.outVars["Min.No.HX"] = gn.nodeVars(
+    node.outVars["Min.No.HX"] = gn.NodeVars(
             unit = "None",
             vdesc = "Minimum number of heat exchangers",
             vst   = "sinter")

--- a/foqus_lib/framework/graph/nodeVars.py
+++ b/foqus_lib/framework/graph/nodeVars.py
@@ -341,7 +341,7 @@ class NodeVars(object):
         elif self.dtype == str:
             return "str"
         else:
-            raise NodeVarEx(11, msg=str(dtype))
+            raise NodeVarEx(11, msg=str(self.dtype))
 
     def makeNaN(self):
         """
@@ -476,7 +476,7 @@ class NodeVars(object):
                     * (power(10, (val - self.min) / (self.max - self.min)) - 1)
                 )
             else:
-                raise
+                raise (f"Unknown scaling: {self.scaling}")
         except:
             raise NodeVarEx(
                 code=9,
@@ -507,7 +507,7 @@ class NodeVars(object):
             elif self.scaling == "Power 2":
                 out = log10(9.0 * val / 10.0 + 1) * (self.max - self.min) + self.min
             else:
-                raise
+                raise (f"Unknown scaling: {self.scaling}")
         except:
             raise NodeVarEx(
                 code=9,
@@ -533,7 +533,7 @@ class NodeVars(object):
         elif self.dtype == str:
             sd["dtype"] = "str"
         else:
-            raise NodeVarEx(11, msg=str(dtype))
+            raise NodeVarEx(11, msg=str(self.dtype))
         sd["value"] = value
         sd["min"] = vmin
         sd["max"] = vmax


### PR DESCRIPTION
Addresses #600 

Not 100% sure I fixed the "base raise" statement correctly, please review...

```
************* Module foqus_lib.framework.graph.graph
foqus_lib/framework/graph/graph.py:1350:12: E0704: The raise statement is not inside an except clause (misplaced-bare-raise)
************* Module foqus_lib.framework.graph.heatIntegration
foqus_lib/framework/graph/heatIntegration.py:10:26: E1101: Module 'foqus_lib.framework.graph.node' has no 'nodeVars' member; maybe 'NodeVars'? (no-member)
foqus_lib/framework/graph/heatIntegration.py:17:30: E1101: Module 'foqus_lib.framework.graph.node' has no 'nodeVars' member; maybe 'NodeVars'? (no-member)
foqus_lib/framework/graph/heatIntegration.py:24:31: E1101: Module 'foqus_lib.framework.graph.node' has no 'nodeVars' member; maybe 'NodeVars'? (no-member)
foqus_lib/framework/graph/heatIntegration.py:31:35: E1101: Module 'foqus_lib.framework.graph.node' has no 'nodeVars' member; maybe 'NodeVars'? (no-member)
foqus_lib/framework/graph/heatIntegration.py:35:43: E1101: Module 'foqus_lib.framework.graph.node' has no 'nodeVars' member; maybe 'NodeVars'? (no-member)
foqus_lib/framework/graph/heatIntegration.py:39:43: E1101: Module 'foqus_lib.framework.graph.node' has no 'nodeVars' member; maybe 'NodeVars'? (no-member)
foqus_lib/framework/graph/heatIntegration.py:43:48: E1101: Module 'foqus_lib.framework.graph.node' has no 'nodeVars' member; maybe 'NodeVars'? (no-member)
foqus_lib/framework/graph/heatIntegration.py:47:39: E1101: Module 'foqus_lib.framework.graph.node' has no 'nodeVars' member; maybe 'NodeVars'? (no-member)
foqus_lib/framework/graph/heatIntegration.py:51:32: E1101: Module 'foqus_lib.framework.graph.node' has no 'nodeVars' member; maybe 'NodeVars'? (no-member)
************* Module foqus_lib.framework.graph.OptGraphOptim
foqus_lib/framework/graph/OptGraphOptim.py:85:12: E1101: Instance of 'optim' has no 'f' member; maybe 'g'? (no-member)
foqus_lib/framework/graph/OptGraphOptim.py:131:12: E1101: Instance of 'optim' has no 'f' member; maybe 'g'? (no-member)
************* Module foqus_lib.framework.graph.nodeVars
foqus_lib/framework/graph/nodeVars.py:344:40: E0602: Undefined variable 'dtype' (undefined-variable)
foqus_lib/framework/graph/nodeVars.py:479:16: E0704: The raise statement is not inside an except clause (misplaced-bare-raise)
foqus_lib/framework/graph/nodeVars.py:510:16: E0704: The raise statement is not inside an except clause (misplaced-bare-raise)
foqus_lib/framework/graph/nodeVars.py:536:40: E0602: Undefined variable 'dtype' (undefined-variable)
```