### PR TITLE
Downgrade pandas to 0.25.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ numpy
 cma
 tqdm
 mlrose
-pandas>0.20
+pandas==0.25.3
 pywin32; sys_platform == 'win32'
 adodbapi>=2.6.0.7; sys_platform == 'win32'
 TurbineClient


### PR DESCRIPTION
Addresses #679 by downgrading pandas

This should be addressed by [moving to the new API](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.0.0.html#backwards-incompatible-api-changes) with the 1.0 release of panda.