### PR TITLE
Upoading csv samples to UQ tab - revised code

### DIFF
--- a/foqus_lib/framework/uq/LocalExecutionModule.py
+++ b/foqus_lib/framework/uq/LocalExecutionModule.py
@@ -422,8 +422,7 @@ class LocalExecutionModule(object):
         numSamples = nlines - 1
         numInputs = len(nums)
         numOutputs = 0
-        if len(nums) == 3:
-            numOutputs = int(nums[2])
+
         # process samples
         data = [None]*numSamples
         for i in range(nlines-k-1):


### PR DESCRIPTION
These lines of code give an error while viewing and analyzing csv files with 3 input variables. I tried to remove these lines, and its possible to upload, view, and analyze the csv samples without them. I have checked it with a few csv files. It would be helpful if someone else could verify this too. 