### PR TITLE
pip install ccsi-foqus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install -qr requirements-dev.txt
+            pip install --progress-bar=off -r requirements-dev.txt
 
       - persist_to_workspace:
           root: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,12 +44,6 @@ jobs:
             pip install -q pytest coverage pylint
 
       - run:
-          name: Run PyLint
-          command: |
-            . venv/bin/activate
-            pylint -E foqus_lib --extension-pkg-whitelist=PyQt5 --ignored-modules=win32process,win32api,adodbapi || true
-
-      - run:
           name: Run Tests
           command: |
             . venv/bin/activate
@@ -62,6 +56,19 @@ jobs:
             coverage report --omit=*site-packages* --fail-under=26
             coverage html --omit=*site-packages*  -d test-results/coverage # Generate html report
             coverage xml --omit=*site-packages* -o test-results/coverage/report.xml
+
+      - run:
+          name: Test Docs
+          command: |
+            . venv/bin/activate
+            cd docs
+            make CLOPTS="-qW --keep-going" clean dummy
+
+      - run:
+          name: PyLint
+          command: |
+            . venv/bin/activate
+            pylint -E foqus_lib --extension-pkg-whitelist=PyQt5 --ignored-modules=win32process,win32api,adodbapi || true
 
       - store_artifacts:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,17 +11,11 @@ jobs:
       - checkout
 
       - run:
-          name: Install Requirements
+          name: Install FOQUS
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install -qr requirements.txt
-
-      - run:
-          name: Install FOQUS
-          command: |
-            . venv/bin/activate
-            python3 setup.py -q install
+            pip install -qr requirements-dev.txt
 
       - persist_to_workspace:
           root: ~/repo
@@ -36,12 +30,6 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/repo
-
-      - run:
-          name: Setup Testing Environment
-          command: |
-            . venv/bin/activate
-            pip install -q pytest coverage pylint
 
       - run:
           name: Run Tests

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__/
 
 # Distribution / packaging
 build/
+dist/
 DLLs/
 Debug/
 Release/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,11 +6,11 @@ install:
     set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
 
 
-    conda create -qy -n foqus python=3.7.5 pip
+    conda create -qy -n foqus python=3.7 pip
 
     activate foqus
 
-    pip install --progress-bar=off -r requirements-dev.txt
+    pip install -r requirements-dev.txt
 
     curl -fsSL -o psuade_project-1.7.12-win32.exe https://github.com/LLNL/psuade/releases/download/1.7.12/psuade_project-1.7.12-win32.exe
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,7 @@ install:
 
     activate foqus
 
-    pip install -e .
-
-    pip install -q pytest pylint coverage
+    pip install --progress-bar=off -r requirements-dev.txt
 
     curl -fsSL -o psuade_project-1.7.12-win32.exe https://github.com/LLNL/psuade/releases/download/1.7.12/psuade_project-1.7.12-win32.exe
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ install:
     set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
 
 
-    conda create -qy -n foqus python=3.7 pip
+    conda create -qy -n foqus python=3.7.5 pip
 
     activate foqus
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ install:
     set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
 
 
-    conda create -qy -n foqus 'python>=3.7.5, <3.8' pip
+    conda create -qy -n foqus python=3.7 pip
 
     activate foqus
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ install:
     set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
 
 
-    conda create -qy -n foqus python=3.7 pip
+    conda create -qy -n foqus 'python>=3.7.5, <3.8' pip
 
     activate foqus
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,12 +3,12 @@ image: Visual Studio 2019
 environment:
   MINICONDA: C:\Miniconda3
 install:
-- sh: >-
+- cmd: >-
     set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
 
     conda create -qy --name foqus 'python>=3.7.5, <3.8' pip
 
-    conda activate foqus
+    activate foqus
 
     pip install -r requirements-dev.txt
 
@@ -17,10 +17,10 @@ install:
     psuade_project-1.7.12-win32.exe /S
 build: off
 test_script:
-- sh: >-
+- cmd: >-
     set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
 
-    conda activate foqus
+    activate foqus
 
     pylint -E foqus_lib --extension-pkg-whitelist=PyQt5
 
@@ -28,6 +28,6 @@ test_script:
 
     mkdir gui_testing
 
-    python foqus.py -s test/system_test/ui_test_01.py --working_dir gui_testing
+    python -W ignore::FutureWarning foqus.py -s test/system_test/ui_test_01.py --working_dir gui_testing
 
     # python foqus.py -s "examples/Smoke Tests/fs_smoke_test.py"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,35 +1,30 @@
 version: 1.0.{build}
+image: Visual Studio 2019
+init:
+- cmd: >-
+    set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
+    conda create -qy --name foqus 'python>=3.7.5, <3.8' pip
+
 environment:
   MINICONDA: C:\Miniconda3
+
 install:
 - cmd: >-
     set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
 
-
-    conda create -qy -n foqus 'python>=3.7.5, <3.8' pip
-
-    activate foqus
-
+    conda activate foqus
     pip install -r requirements-dev.txt
-
     curl -fsSL -o psuade_project-1.7.12-win32.exe https://github.com/LLNL/psuade/releases/download/1.7.12/psuade_project-1.7.12-win32.exe
-
     psuade_project-1.7.12-win32.exe /S
-build_script:
-- cmd: python setup.py -q install
+
+build: off
+
 test_script:
 - ps: >-
-    activate foqus
-
-
+    set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
+    conda activate foqus
     pylint -E foqus_lib --extension-pkg-whitelist=PyQt5
-
-
     coverage run -m pytest
-
-
     mkdir gui_testing
-
-    python -W ignore::FutureWarning foqus.py -s test/system_test/ui_test_01.py --working_dir gui_testing
-
+    python foqus.py -s test/system_test/ui_test_01.py --working_dir gui_testing
     # python foqus.py -s "examples/Smoke Tests/fs_smoke_test.py"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,12 +1,12 @@
 version: 1.0.{build}
-image: Visual Studio 2019
 environment:
   MINICONDA: C:\Miniconda3
 install:
 - cmd: >-
     set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
 
-    conda create -qy --name foqus 'python>=3.7.5, <3.8' pip
+
+    conda create -qy -n foqus 'python>=3.7.5, <3.8' pip
 
     activate foqus
 
@@ -15,16 +15,18 @@ install:
     curl -fsSL -o psuade_project-1.7.12-win32.exe https://github.com/LLNL/psuade/releases/download/1.7.12/psuade_project-1.7.12-win32.exe
 
     psuade_project-1.7.12-win32.exe /S
-build: off
+build_script:
+- cmd: python setup.py -q install
 test_script:
-- cmd: >-
-    set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
-
+- ps: >-
     activate foqus
+
 
     pylint -E foqus_lib --extension-pkg-whitelist=PyQt5
 
+
     coverage run -m pytest
+
 
     mkdir gui_testing
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,12 +3,12 @@ image: Visual Studio 2019
 environment:
   MINICONDA: C:\Miniconda3
 install:
-- cmd: >-
+- sh: >-
     set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
 
     conda create -qy --name foqus 'python>=3.7.5, <3.8' pip
 
-    CALL conda.bat activate foqus
+    conda activate foqus
 
     pip install -r requirements-dev.txt
 
@@ -17,10 +17,10 @@ install:
     psuade_project-1.7.12-win32.exe /S
 build: off
 test_script:
-- cmd: >-
+- sh: >-
     set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
 
-    CALL conda.bat activate foqus
+    conda activate foqus
 
     pylint -E foqus_lib --extension-pkg-whitelist=PyQt5
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,28 +3,34 @@ image: Visual Studio 2019
 init:
 - cmd: >-
     set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
-    conda create -qy --name foqus 'python>=3.7.5, <3.8' pip
 
+    conda create -qy --name foqus 'python>=3.7.5, <3.8' pip
 environment:
   MINICONDA: C:\Miniconda3
-
 install:
 - cmd: >-
     set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
 
     conda activate foqus
+
     pip install -r requirements-dev.txt
+
     curl -fsSL -o psuade_project-1.7.12-win32.exe https://github.com/LLNL/psuade/releases/download/1.7.12/psuade_project-1.7.12-win32.exe
+
     psuade_project-1.7.12-win32.exe /S
-
 build: off
-
 test_script:
 - ps: >-
     set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
+
     conda activate foqus
+
     pylint -E foqus_lib --extension-pkg-whitelist=PyQt5
+
     coverage run -m pytest
+
     mkdir gui_testing
+
     python foqus.py -s test/system_test/ui_test_01.py --working_dir gui_testing
+
     # python foqus.py -s "examples/Smoke Tests/fs_smoke_test.py"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,12 @@
 version: 1.0.{build}
 image: Visual Studio 2019
-init:
-- cmd: >-
-    set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
-
-
-    conda create -qy --name foqus 'python>=3.7.5, <3.8' pip
 environment:
   MINICONDA: C:\Miniconda3
 install:
 - cmd: >-
     set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
+
+    conda create -qy --name foqus 'python>=3.7.5, <3.8' pip
 
     conda activate foqus
 
@@ -21,7 +17,7 @@ install:
     psuade_project-1.7.12-win32.exe /S
 build: off
 test_script:
-- ps: >-
+- cmd: >-
     set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
 
     conda activate foqus

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,11 +6,11 @@ install:
     set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
 
 
-    conda create -qy -n foqus python=3.7.5 pip
+    conda create -qy -n foqus python=3.7 pip
 
     activate foqus
 
-    pip install -qr requirements.txt
+    pip install -e .
 
     pip install -q pytest pylint coverage
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ install:
 
     conda create -qy --name foqus 'python>=3.7.5, <3.8' pip
 
-    conda activate foqus
+    CALL conda.bat activate foqus
 
     pip install -r requirements-dev.txt
 
@@ -20,7 +20,7 @@ test_script:
 - cmd: >-
     set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
 
-    conda activate foqus
+    CALL conda.bat activate foqus
 
     pylint -E foqus_lib --extension-pkg-whitelist=PyQt5
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ init:
 - cmd: >-
     set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%
 
+
     conda create -qy --name foqus 'python>=3.7.5, <3.8' pip
 environment:
   MINICONDA: C:\Miniconda3

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,16 +3,17 @@
 
 # You can set these variables from the command line.
 # DATE          = $(shell date +%Y-%m-%d_%H%M%S)
-SPHINXOPTS    = -w sphinx-build.log -T 
+SPHINXOPTS    = -w sphinx-build.log
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build
 SCRIPTDIR     = scripts
+CLOPTS        =
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+ALLSPHINXOPTS   = $(CLOPTS) -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 
@@ -56,7 +57,7 @@ clean:
 
 .PHONY: apidoc
 apidoc:
-	sphinx-apidoc -fM --separate -o source/apidoc ../idaes ../idaes/tests "../idaes/*/tests"
+	sphinx-apidoc -fM --separate -o source/apidoc ../foqus_lib ../foqus_lib/tests "../foqus_lib/*/tests"
 
 .PHONY: dep
 dep: apidoc

--- a/docs/source/chapt_debug/index.rst
+++ b/docs/source/chapt_debug/index.rst
@@ -85,8 +85,9 @@ The following are known unresolved issues:
 Reporting Issues
 ----------------
 
-| To report an issue, please send an email to:
-| 
+To report an issue or ask a question, send an email to:
+ccsi-support@acceleratecarboncapture.org or open an issue at:
+https://github.com/CCSI-Toolset/FOQUS
 
-Please include detailed steps on how to reproduce the error, including
-screenshots and log files.
+Please include detailed steps on how to reproduce the error, including if
+possible, screenshots and log files.

--- a/foqus_lib/version/version.template
+++ b/foqus_lib/version/version.template
@@ -22,6 +22,6 @@ support = "ccsi-support@acceleratecarboncapture.org"
 webpage = "http://www.acceleratecarboncapture.org/"
 maintainer = "CCSI FOQUS Team"
 maintainer_email = "ccsi-support@acceleratecarboncapture.org"
-description = ("FOQUS tool for simulation based optimization,"
-              " uncertainty quantification, and surrogate modeling")
-name = "foqus"
+description = ("FOQUS tool for Simulation based Optimization,"
+              " Uncertainty Quantification, and Surrogate modeling")
+name = "ccsi-foqus"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,9 @@
 --index-url https://pypi.python.org/simple/
 
 # These will override requirements picked up from setup.py below:
-coverage==4.5.4
+coverage
 pylint
+pytest
 pytest-cov
 sphinx
 sphinx_rtd_theme

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,11 @@
+--index-url https://pypi.python.org/simple/
+
+# These will override requirements picked up from setup.py below:
+coverage==4.5.4
+pylint
+pytest-cov
+sphinx
+sphinx_rtd_theme
+
+# Pick up requirements from setup.py
+-e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,16 @@
-PyQt5==5.13.*
-boto3
-psutil
-sphinx
-sphinx_rtd_theme
-matplotlib
-scipy
-numpy
-cma
-tqdm
-mlrose
-pandas
-pywin32; sys_platform == 'win32'
-adodbapi>=2.6.0.7; sys_platform == 'win32'
-TurbineClient
+--index-url https://pypi.python.org/simple/
+
+# The end-user requirements list has moved into setup.py in the install_requires
+# list.
+
+# This file should stay empty of new requirements (other than the "-e ." below)
+
+# Developers should now use "pip install -r requirements.txt" (or "pip install -e .")
+# to setup their development environments (don't use "python setup.py [install|develop]").
+
+# Developer needed requirements (sphinx, pytest, etc.) should go in
+# requirement-dev.txt and can be installed with "pip install -r requirement-dev.txt"
+# (which is a superset of what "pip install -r requirements.txt" will install.
+
+# Pick up requirements from setup.py
+-e .

--- a/setup.py
+++ b/setup.py
@@ -85,8 +85,11 @@ def write_bat(bat_file, python_path, conda_path, conda_env, foqus_path, switch):
 
 if os.name == 'nt': # Write a batch file on windows to make it easier to launch
     #first see if this is a conda env
-    foqus_path = subprocess.check_output(
-        ["where", "$PATH:foqus.py"]).decode('utf-8').split("\n")[0].strip()
+    print("  Writing batch files for Windows")
+    co = subprocess.check_output(["where", "foqus.py"])
+    print(f"  co: {co}")
+    foqus_path = co.decode('utf-8').split(os.linesep)[0].strip()
+    print(f"  foqus_path: {foqus_path}")
     if "CONDA_DEFAULT_ENV" in os.environ: # we're using conda probably
         conda_env = os.environ["CONDA_DEFAULT_ENV"]
         conda_path = shutil.which("conda") # unless conda is not found

--- a/setup.py
+++ b/setup.py
@@ -53,25 +53,23 @@ dist = setup(
         'cloud/aws/foqus_worker.py',
         'cloud/aws/foqus_service.py',
         'icons_rc.py'],
-    # Put abstract (non-versioned) deps here.
-    # Concrete dependencies go in requirements[-dev].txt
+    # Required packages needed in the users env go here (non-versioned strongly preferred).
+    # requirements.txt should stay empty (other than the "-e .")
     install_requires=[
-        "PyQt5==5.13.*",
-        "boto3",
-        "psutil",
-        "sphinx",
-        "sphinx_rtd_theme",
-        "matplotlib",
-        "scipy",
-        "numpy",
-        "cma",
-        "tqdm",
-        "mlrose",
-        "pandas",
-        "pywin32; sys_platform == 'win32'",
         "adodbapi>=2.6.0.7; sys_platform == 'win32'",
+        "cma",
+        "matplotlib",
+        "mlrose",
+        "numpy",
+        "pandas",
+        "psutil",
+        "PyQt5==5.13.*",
+        "pywin32; sys_platform == 'win32'",
+        "requests",
+        "scipy",
+        "tqdm",
         "TurbineClient",
-        ]
+        ],
 )
 
 def write_bat(bat_file, python_path, conda_path, conda_env, foqus_path, switch):

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,11 @@ import shutil
 # default_version is the version if "git describe --tags" falls through
 # Addtional package info is set in foqus_lib/version/version.template.
 # The version module, just makes it a bit easier for FOQUS to pull package info
-default_version = "3.5.0dev2"
+default_version = "3.5.0dev3"
 
 try:
     version=subprocess.check_output(
+        ## Undo the 'n' here, this is just testing without having to put in a real tag ##
         ["ngit", "describe", "--tags", "--abbrev=0"]).decode('utf-8').strip()
     version = version.replace("-", ".dev", 1)
     version = version.replace("-", "+", 1)

--- a/setup.py
+++ b/setup.py
@@ -85,11 +85,8 @@ def write_bat(bat_file, python_path, conda_path, conda_env, foqus_path, switch):
 
 if os.name == 'nt': # Write a batch file on windows to make it easier to launch
     #first see if this is a conda env
-    print("  Writing batch files for Windows")
-    co = subprocess.check_output(["where", "foqus.py"])
-    print(f"  co: {co}")
-    foqus_path = co.decode('utf-8').split(os.linesep)[0].strip()
-    print(f"  foqus_path: {foqus_path}")
+    foqus_path = subprocess.check_output(
+        ["where", "foqus.py"]).decode('utf-8').split(os.linesep)[0].strip()
     if "CONDA_DEFAULT_ENV" in os.environ: # we're using conda probably
         conda_env = os.environ["CONDA_DEFAULT_ENV"]
         conda_path = shutil.which("conda") # unless conda is not found

--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,11 @@ import shutil
 # default_version is the version if "git describe --tags" falls through
 # Addtional package info is set in foqus_lib/version/version.template.
 # The version module, just makes it a bit easier for FOQUS to pull package info
-default_version = "3.5.0dev"
+default_version = "3.5.0dev2"
 
 try:
     version=subprocess.check_output(
-        ["git", "describe", "--tags"]).decode('utf-8').strip()
+        ["ngit", "describe", "--tags", "--abbrev=0"]).decode('utf-8').strip()
     version = version.replace("-", ".dev", 1)
     version = version.replace("-", "+", 1)
 except:
@@ -52,7 +52,26 @@ dist = setup(
         'foqus.py',
         'cloud/aws/foqus_worker.py',
         'cloud/aws/foqus_service.py',
-        'icons_rc.py']
+        'icons_rc.py'],
+    # Put abstract (non-versioned) deps here.
+    # Concrete dependencies go in requirements[-dev].txt
+    install_requires=[
+        "PyQt5==5.13.*",
+        "boto3",
+        "psutil",
+        "sphinx",
+        "sphinx_rtd_theme",
+        "matplotlib",
+        "scipy",
+        "numpy",
+        "cma",
+        "tqdm",
+        "mlrose",
+        "pandas",
+        "pywin32; sys_platform == 'win32'",
+        "adodbapi>=2.6.0.7; sys_platform == 'win32'",
+        "TurbineClient",
+        ]
 )
 
 def write_bat(bat_file, python_path, conda_path, conda_env, foqus_path, switch):

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ dist = setup(
     # requirements.txt should stay empty (other than the "-e .")
     install_requires=[
         "adodbapi>=2.6.0.7; sys_platform == 'win32'",
+        "boto3",
         "cma",
         "matplotlib",
         "mlrose",


### PR DESCRIPTION
Changes so that a pypi package can be created.

There's a few changes here to where requirements live and how to setup a developers env.

Regular "end-user" requirements now live in `setup.py` in the `install_requires` list.  They should **_not_** live in `requirements.txt` anymore.  All that's left in `requirements.txt` now (beyond comments) is the line `-e .` which means "look in setup.py".

I've also moved "developer" requirements into a new `requirements-dev.txt` file so that people who don't want those can not bother with them.

This changes (a little) how a developer setup up their environment.  The new instructions are (I will put these in the docs, but here they are for now):

1. Create a new conda env (here named "foqus")
    ```
    conda deactivate
    conda remove --name foqus --all
    conda create --name foqus python-3.7
    conda activate foqus
    ```
2. Install requirements:
    ```
    cd <your foqus working dir>
    pip install -r requirements.txt  # or pip install -r requirements-dev.txt
    ./foqus.py   # note the "./" there as the above line will also install a foqus.py in your conda env
    ```
There's no longer the need to run `python setup.py [install|develop]`.  (In fact, you don't want to it doesn't install PyQt5 correctly.)

ToDos:
 - [ ] Update developer docs for how to create developer env
 - [x] Add a wiki page on how to build package for pypi
 - [ ] Update install docs on how to use `pip install ccsi-foqus`