### PR TITLE
[WIP] Improve `pip install` on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -154,4 +154,4 @@ Windows:
         - foqus.bat: run FOQUS and close cmd window when FOQUS exits
         - foqus_debug.bat: run FOQUS and leave cmd window open  
 ==============================================================================
-"""
+""")


### PR DESCRIPTION
When installing via `pip install ccsi-foqus` on Windows, the batch files do not get created properly.  Specifically, the code generating them has several assumptions which may or may not be true: 

- It's run in a conda env (could just be virtualenv, the system python a/o with `pip install --user`
- There's a copy of the source in the current dir (the goal is for the end-user to NOT need the source)
- It is run on Windows (setup.py might be run on unix to generate a wheel that could be installed on Windows)

The larger goal here is to make it easier for a Windows user to install and start FOQUS.

It appears that [bdist_wininst is going away with python 3.8](https://discuss.python.org/t/deprecate-bdist-wininst/1929).  Hopefully there's a way to still work with a [wheel](https://pip.pypa.io/en/latest/user_guide/#installing-from-wheels) that will work on Windows.  Ultiumately a full-blown Windows installer is the way to go, but hopefully there's a mid-point here with pip and wheels.