### PR TITLE
Pylint fixes for foqus_lib/foqus.py

### DIFF
--- a/foqus_lib/foqus.py
+++ b/foqus_lib/foqus.py
@@ -28,7 +28,7 @@ splashScr = [None, None] # [0] splash timer, [1] splash screen
 foqus_application = None # The Qt application so I can show dialogs
 # global variables
 dat = None
-
+PyQt5 = None
 
 def guiImport():
     """
@@ -37,21 +37,10 @@ def guiImport():
     global loadGUI
     global guiAvail
     global dmf_lib
-    global QtCore
-    global QApplication
-    global QSplashScreen
-    global QMessageBox
-    global QFileDialog
-    global QPixmap
-    global QPainter
+    global PyQt5
     # GUI Imports
     try: # Check if the PySide libraries are available
-        from PyQt5 import QtCore
-        from PyQt5.QtWidgets import QApplication, QSplashScreen, QMessageBox, \
-            QFileDialog
-        from PyQt5.QtGui import QPixmap, QPainter
-        from PyQt5 import QtSvg
-
+        import PyQt5
         import matplotlib
         matplotlib.use('Qt5Agg')
         matplotlib.rcParams['backend']='Qt5Agg'
@@ -77,9 +66,9 @@ def makeSplash():
     information
     """
     # Load the splash screen background svg, gonna draw text over
-    pixmap = QPixmap(':/icons/icons/ccsiSplash2.svg')
+    pixmap = PyQt5.QtGui.QPixmap(':/icons/icons/ccsiSplash2.svg')
     # Make a painter to add text to
-    painter = QPainter(pixmap)
+    painter = PyQt5.QtGui.QPainter(pixmap)
     font = painter.font()  # current font for drawing text
     font.setPointSize(8)
     font.setBold(True)
@@ -88,16 +77,16 @@ def makeSplash():
     font.setBold(False)
     painter.setFont(font)
     painter.drawText(20, 200, 740, 50,
-        QtCore.Qt.AlignTop|QtCore.Qt.AlignLeft|QtCore.Qt.TextWordWrap,
+        PyQt5.QtCore.Qt.AlignTop|PyQt5.QtCore.Qt.AlignLeft|PyQt5.QtCore.Qt.TextWordWrap,
         "License: {}".format(ver.license))
     painter.drawText(20, 250, 740, 50,
-        QtCore.Qt.AlignTop|QtCore.Qt.AlignLeft|QtCore.Qt.TextWordWrap,
+        PyQt5.QtCore.Qt.AlignTop|PyQt5.QtCore.Qt.AlignLeft|PyQt5.QtCore.Qt.TextWordWrap,
         "Support: {}".format(ver.support))
     painter.drawText(20, 300, 740, 300,
-        QtCore.Qt.AlignTop|QtCore.Qt.AlignLeft|QtCore.Qt.TextWordWrap,
+        PyQt5.QtCore.Qt.AlignTop|PyQt5.QtCore.Qt.AlignLeft|PyQt5.QtCore.Qt.TextWordWrap,
         ver.copyright)
     painter.end()
-    splashScr[1] = QSplashScreen(pixmap=pixmap)
+    splashScr[1] = PyQt5.QtWidgets.QSplashScreen(pixmap=pixmap)
 
 def startGUI(showSplash=False, app=None, showUQ=True, showOpt=True,
              showBasicData=True, showSDOE = True, ts = None):
@@ -114,19 +103,19 @@ def startGUI(showSplash=False, app=None, showUQ=True, showOpt=True,
     """
     import foqus_lib.gui.main.mainWindow as MW
     if app == None:
-        app = QApplication(sys.argv)
+        app = PyQt5.QtWidgets.QApplication(sys.argv)
     #create main window and start application loop
     makeSplash()
     if showSplash:
         #add timer to show splash
-        splashScr[0] = QtCore.QTimer()
+        splashScr[0] = PyQt5.QtCore.QTimer()
         splashScr[0].timeout.connect(hideSplash)
         # splash_timeout_ms is how long to show splash in ms
         # it is set in the first code line of this file
         splashScr[0].start(splash_timeout_ms)
         splashScr[1].setWindowFlags(
             splashScr[1].windowFlags()|
-            QtCore.Qt.WindowStaysOnTopHint)
+            PyQt5.QtCore.Qt.WindowStaysOnTopHint)
         splashScr[1].show()
 
     mainWin = MW.mainWindow(
@@ -163,7 +152,7 @@ def logException(etype, evalue, etrace):
             # cursor was set to waiting type set to normal
             foqus_application.restoreOverrideCursor()
             # Now show error in a message box
-            msgBox = QMessageBox()
+            msgBox = PyQt5.QtWidgets.QMessageBox()
             msgBox.setWindowTitle("Error")
             msgBox.setText("Unhandled Exception:")
             msgBox.setInformativeText(
@@ -187,6 +176,7 @@ def signal_handler(signal, frame):
     raise KeyboardInterrupt()
 
 def main():
+    print("ksb")
     global dat
     exit_code = 0 # Proc exit code
     # Set up the basic logging stuff here, later after the working
@@ -321,7 +311,7 @@ def main():
     if guiAvail and not args.nogui and not nogui:
         # start up a Qt app so I can display GUI messages
         # instead of printing to console
-        app = QApplication(sys.argv)
+        app = PyQt5.QtWidgets.QApplication(sys.argv)
         foqus_application = app
     else: # if no gui, I'll fall back to print
         app = None
@@ -362,15 +352,15 @@ def main():
                     # gui is available ask about working dir
                     # and write config file
                     settings = {'working_dir': None}
-                    msg = QMessageBox()
+                    msg = PyQt5.QtWidgets.QMessageBox()
                     msg.setText(("The user working directory has not "
                         "been specified yet. \nPlease create a FOQUS "
                         "working directory and specify its location "
                         "after pressing okay."))
                     msg.exec_()
-                    msg = QFileDialog()
-                    msg.setFileMode(QFileDialog.Directory)
-                    msg.setOption(QFileDialog.ShowDirsOnly)
+                    msg = PyQt5.QtWidgets.QFileDialog()
+                    msg.setFileMode(PyQt5.QtWidgets.QFileDialog.Directory)
+                    msg.setOption(PyQt5.QtWidgets.QFileDialog.ShowDirsOnly)
                     if msg.exec_():
                         dirs = msg.selectedFiles()
                         settings["working_dir"] = dirs[0]
@@ -379,7 +369,7 @@ def main():
                         logging.getLogger("foqus." + __name__)\
                             .error(('No working directory'
                             ' specified. FOQUS will exit'))
-                        msg = QMessageBox()
+                        msg = PyQt5.QtWidgets.QMessageBox()
                         msg.setText(("No working directory"
                             " specified. FOQUS will exit."))
                         msg.exec_()

--- a/foqus_lib/foqus.py
+++ b/foqus_lib/foqus.py
@@ -176,7 +176,6 @@ def signal_handler(signal, frame):
     raise KeyboardInterrupt()
 
 def main():
-    print("ksb")
     global dat
     exit_code = 0 # Proc exit code
     # Set up the basic logging stuff here, later after the working


### PR DESCRIPTION
I've re-worked the PyQt5 imports so that with one global "PyQt5" all the "undefined-variables" errors go away.

There's probably a better way to do this, say for example using a class with "PyQt5" be a member var, though that would be a larger refactor than I'm able to take on right now.  Still, please review if this change makes sense.

This still leaves pylint errors:
```
$ pylint -E foqus_lib/foqus.py
************* Module foqus_lib.foqus
foqus_lib/foqus.py:455:14: E1101: Instance of 'plugins' has no 'optimizers' member (no-member)
foqus_lib/foqus.py:455:41: E1101: Instance of 'plugins' has no 'current' member (no-member)
```
which I'm not sure how to test, so I didn't try changing anything.

This does bring up another question: could we have a canned test to run an optimization problem from the command line as part of an automated test?  Something that would run quickly, smoke-test style would be good.

Part of #600 
