### PR TITLE
pylint should ignore scipy.spatial

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
           name: PyLint
           command: |
             . venv/bin/activate
-            pylint -E foqus_lib --extension-pkg-whitelist=PyQt5 --ignored-modules=win32process,win32api,adodbapi || true
+            pylint -E foqus_lib --extension-pkg-whitelist=PyQt5 --ignored-modules=win32process,win32api,adodbapi,scipy.spatial || true
 
       - store_artifacts:
           path: test-results

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ test_script:
     activate foqus
 
 
-    pylint -E foqus_lib --extension-pkg-whitelist=PyQt5
+    pylint -E foqus_lib --extension-pkg-whitelist=PyQt5 --ignored-modules=scipy.spatial
 
 
     coverage run -m pytest


### PR DESCRIPTION
Adding `scipy.spatial` to ignored modules list as it contains C functions.

This came up when looking at pylint errors in `foqus_lib/framework/ouu/OUU.py`

Part of #600
