### PR TITLE
Add foqus cmd line test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,12 @@ jobs:
             coverage xml --omit=*site-packages* -o test-results/coverage/report.xml
 
       - run:
+          name: Test CL run
+          command: |
+            . venv/bin/activate
+            foqus -l ./examples/test_files/Optimization/Opt_Test_01.foqus --run opt --out test_opt.foqus
+
+      - run:
           name: Test Docs
           command: |
             . venv/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
           name: Test CL run
           command: |
             . venv/bin/activate
-            foqus -l ./examples/test_files/Optimization/Opt_Test_01.foqus --run opt --out test_opt.foqus
+            foqus --load ./examples/test_files/Optimization/Opt_Test_01.foqus --run opt --out test_opt.foqus
 
       - run:
           name: Test Docs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ test_script:
 
     coverage run -m pytest
 
-    foqus -l ./examples/test_files/Optimization/Opt_Test_01.foqus --run opt --out test_opt.foqus
+    foqus --load ./examples/test_files/Optimization/Opt_Test_01.foqus --run opt --out test_opt.foqus
     
     mkdir gui_testing
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,8 @@ test_script:
 
     coverage run -m pytest
 
-
+    foqus -l ./examples/test_files/Optimization/Opt_Test_01.foqus --run opt --out test_opt.foqus
+    
     mkdir gui_testing
 
     foqus -s test/system_test/ui_test_01.py --working_dir gui_testing


### PR DESCRIPTION
This addresses the first part of #795:

Add the command line test of foqus to our CI systems:

    foqus --load ./examples/test_files/Optimization/Opt_Test_01.foqus --run opt --out test_opt.foqus

Add to both appveyor and circleci