### PR TITLE
Pylint-specific configuration and directives to address false-positive errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
           name: PyLint
           command: |
             . venv/bin/activate
-            pylint -E foqus_lib --extension-pkg-whitelist=PyQt5 --ignored-modules=win32process,win32api,adodbapi,scipy.spatial || true
+            pylint --rcfile=.pylint/pylintrc --disable=W,C,R,I foqus_lib || true
 
       - store_artifacts:
           path: test-results

--- a/.pylint/foqus_transform.py
+++ b/.pylint/foqus_transform.py
@@ -1,0 +1,73 @@
+import astroid
+
+
+def register(linter):
+    """
+    This function must be defined for pylint to use this module as a plugin.
+    """
+
+
+def get_pyqtsignal_classdef(context=None):
+    src = (
+        """
+        class pyqtSignal:
+            def __getitem__(self, key):
+                return self
+            def connect(self, slot, type=None, no_receiver_check=False):
+                pass
+            def disconnect(self, slot):
+                pass
+            def emit(self, *args):
+                pass
+        """
+    )
+    clsdef_node = astroid.extract_node(src)
+    inferred_node = astroid.helpers.safe_infer(clsdef_node, context=context)
+    return inferred_node
+
+
+# add here names of pyQt signals incorrectly detected as normal attributes/bound methods
+PYQTSIGNAL_ATTRIBUTE_NAMES = frozenset(
+    [
+        'currentIndexChanged',
+    ]
+)
+
+
+def infer_signal_from_attribute(node: astroid.Attribute, context=None):
+    signal_inst_node = get_pyqtsignal_classdef(context=context).instantiate_class()
+    return iter([signal_inst_node])
+
+
+def _is_attribute_actually_pyqtsignal(node: astroid.Attribute):
+    return node.attrname in PYQTSIGNAL_ATTRIBUTE_NAMES
+
+
+def _is_assign_attr_dat(node: astroid.AssignAttr):
+    # TODO make this more specific, e.g. checking that the assigned value is None
+    return node.attrname == 'dat'
+
+
+def get_session_classdef(context=None):
+    node = astroid.extract_node('from foqus_lib.framework.session.session import session; session')
+    clsdef_node = astroid.helpers.safe_infer(node, context=context)
+    return clsdef_node
+
+
+def infer_session_for_attr(node: astroid.AssignAttr, context=None):
+    inst_node = get_session_classdef(context=context).instantiate_class()
+    return iter([inst_node])
+
+
+astroid.MANAGER.register_transform(
+    astroid.Attribute,
+    astroid.inference_tip(infer_signal_from_attribute),
+    _is_attribute_actually_pyqtsignal,
+)
+
+
+astroid.MANAGER.register_transform(
+    astroid.AssignAttr,
+    astroid.inference_tip(infer_session_for_attr),
+    _is_assign_attr_dat,
+)

--- a/.pylint/pylintrc
+++ b/.pylint/pylintrc
@@ -1,0 +1,8 @@
+
+[MASTER]
+init-hook="import sys; sys.path.append('.pylint')"
+load-plugins=foqus_transform
+extension-pkg-whitelist=PyQt5
+
+[TYPECHECK]
+ignored-modules=win32process,win32api,winshell,adodbapi,scipy.spatial

--- a/foqus_lib/framework/optimizer/problem.py
+++ b/foqus_lib/framework/optimizer/problem.py
@@ -345,7 +345,7 @@ class problem(object):
         '''
         if self.objtype == self.OBJ_TYPE_CUST:
             exec(self.custpy,globals())
-            self.custObjFunc = objfunc
+            self.custObjFunc = objfunc  # pylint: disable=undefined-variable
         self.inpDict = slv.graph.saveValues()['input']
 
     def calculateObj(self, svlist, nsamples = 1):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,12 @@
 
 # These will override requirements picked up from setup.py below:
 coverage
-pylint
+# pinning the pylint version to ensure reproducible behavior and defaults
+pylint==2.6.0
+# also pinning the version for astroid (used by pylint to analyze the AST)
+# since there can be significant differences between (non-major) versions,
+# both in terms of behavior and performance
+astroid==2.4.2
 pytest
 pytest-cov
 sphinx


### PR DESCRIPTION
This PR implements changes aimed at getting rid of false-positive errors, i.e. portions of the codebase that are erroneously interpreted as errors by the pylint static analysis.

This is part of the efforts towards addressing #600. Specifically, this PR contains only changes that affect pylint exclusively, and thus **do not alter** the runtime behavior of the code in any way, i.e.:

- pylint configuration
- pylint commands in the CI configuration
- pylint directives expressed as comments throughout the codebase

The idea is to keep those sets of changes that do affect the code itself (and that therefore could alter the runtime behavior) in dedicated PRs, to streamline both the fixes and the review process. In other words, reviews for this PR can concentrate entirely on the pylint analysis, without having to take into account compatibility, introducing regressions, or other code-specific considerations.

In addition, these changes aggregate most of the configuration into the pylint RC file located at `.pylint/pylintrc`, allowing to share the same settings among different use cases in addition to CI checks, e.g. direct invocation, and integration with IDEs/editors supporting static analysis with pylint.