### PR TITLE
pylint: add missing import

### DIFF
--- a/foqus_lib/framework/listen/listen.py
+++ b/foqus_lib/framework/listen/listen.py
@@ -8,6 +8,9 @@
 John Eslick, Carnegie Mellon University, 2014
 See LICENSE.md for license and copyright details.
 """
+
+
+import logging
 from multiprocessing.connection import Listener
 import threading
 import time


### PR DESCRIPTION
This should be a straightforward fix for the missing import caught by pylint described in #807.