### PR TITLE
Refactor method args to get rid of pylint false-positive errors

### DIFF
--- a/foqus_lib/framework/uq/Model.py
+++ b/foqus_lib/framework/uq/Model.py
@@ -272,9 +272,7 @@ class Model:
     def getNamesIncludeNodes(self):
         return self.namesIncludeNodes
 
-    def setInputNames(*arg):
-        self = arg[0] #Reference to self
-        names = arg[1:]
+    def setInputNames(self, *names):
         if len(names) == 1:
             #Remove single value from tuple. Needed if argument is a collection
             names = names[0]
@@ -293,9 +291,7 @@ class Model:
         self.inputNames = tuple([str(name) for name in self.inputNames])
         return self.inputNames
 
-    def setOutputNames(*arg):
-        self = arg[0] #Reference to self
-        names = arg[1:]
+    def setOutputNames(self, *names):
         if len(names) == 1:
             names = names[0]
         if isinstance(names, str): #Single string


### PR DESCRIPTION
Part of the efforts towards #600.

- [x]  `foqus_lib.framework.uq.Model:L275` ([link](https://github.com/CCSI-Toolset/FOQUS/blob/master/foqus_lib/framework/uq/Model.py#L275)) Method has no argument
- [x]  `foqus_lib.framework.uq.Model:L296` ([link](https://github.com/CCSI-Toolset/FOQUS/blob/master/foqus_lib/framework/uq/Model.py#L296)) Method has no argument

These errors are false positives, in the sense that the code works, but the slightly unusual syntax seems to annoy pylint. The changes in this PR are a possible solution for using a more idiomatic syntax that also manages to make pylint happy.