### PR TITLE
Address PyQt-related errors when initializing GUI in foqus_lib.foqus

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,10 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install --progress-bar=off -r requirements-dev.txt
+      - run:
+          name: Install system packages needed to run GUI-related PyQt tests
+          command: |
+            apt update && apt install -y libxkbcommon-x11-0 x11-utils
 
       - persist_to_workspace:
           root: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,6 @@ jobs:
             python3 -m venv venv
             . venv/bin/activate
             pip install --progress-bar=off -r requirements-dev.txt
-      - run:
-          name: Install system packages needed to run GUI-related PyQt tests
-          command: |
-            sudo apt-get update && sudo apt-get install -y libxkbcommon-x11-0 x11-utils
 
       - persist_to_workspace:
           root: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       - run:
           name: Install system packages needed to run GUI-related PyQt tests
           command: |
-            apt update && apt install -y libxkbcommon-x11-0 x11-utils
+            sudo apt-get update && sudo apt-get install -y libxkbcommon-x11-0 x11-utils
 
       - persist_to_workspace:
           root: ~/repo

--- a/foqus_lib/foqus.py
+++ b/foqus_lib/foqus.py
@@ -41,6 +41,14 @@ def guiImport():
     # GUI Imports
     try: # Check if the PySide libraries are available
         import PyQt5
+        # QtWidgets, QtGui, and QtCore are used in this module,
+        # but they might not be available in PyQt5 without importing them first
+        # in most circumstances, they will be already imported
+        # from the imports in foqus_lib.framework.session.session
+        # to be on the safe side, we run these imports explicitly here, too
+        import PyQt5.QtWidgets
+        import PyQt5.QtGui
+        import PyQt5.QtCore
         import matplotlib
         matplotlib.use('Qt5Agg')
         matplotlib.rcParams['backend']='Qt5Agg'

--- a/foqus_lib/unit_test/test_foqus_main.py
+++ b/foqus_lib/unit_test/test_foqus_main.py
@@ -65,4 +65,3 @@ def test_gui_imports():
     if foqus.PyQt5 is None:
         foqus.guiImport()
     assert foqus.PyQt5 is not None, "After running guiImport(), foqus.PyQt5 points to the actual module instead of the placeholder value None"
-    assert foqus.PyQt5.QtWidgets.QApplication([]) is not None, "Once the GUI imports have been set up, a QApplication can be created without errors"

--- a/foqus_lib/unit_test/test_foqus_main.py
+++ b/foqus_lib/unit_test/test_foqus_main.py
@@ -59,3 +59,10 @@ def test_start_gui():
     cli_args = []
     with pytest.raises(SystemExit, match="0"):
         foqus.main(cli_args)
+
+
+def test_gui_imports():
+    if foqus.PyQt5 is None:
+        foqus.guiImport()
+    assert foqus.PyQt5 is not None, "After running guiImport(), foqus.PyQt5 points to the actual module instead of the placeholder value None"
+    assert foqus.PyQt5.QtWidgets.QApplication([]) is not None, "Once the GUI imports have been set up, a QApplication can be created without errors"

--- a/foqus_lib/unit_test/test_foqus_main.py
+++ b/foqus_lib/unit_test/test_foqus_main.py
@@ -52,3 +52,10 @@ def test_run_optimization_with_nonexisting_input_file_fails(nonexisting_input_fi
 
     with pytest.raises(SystemExit, match='10'):
         foqus.main(cli_args)
+
+
+@pytest.mark.requires_human("Close the GUI window manually to complete the test")
+def test_start_gui():
+    cli_args = []
+    with pytest.raises(SystemExit, match="0"):
+        foqus.main(cli_args)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,10 @@
 [pytest]
-addopts = -W ignore --ignore foqus_lib/framework/solventfit
+# by default, skip tests requiring human intervention
+addopts = -W ignore --ignore foqus_lib/framework/solventfit -m 'not requires_human'
 testpaths = foqus_lib
 log_file = pytest.log
 log_file_date_format = %Y-%m-%dT%H:%M:%S
 log_file_format = %(asctime)s %(levelname)-7s <%(filename)s:%(lineno)d> %(message)s
 log_file_level = DEBUG
+markers =
+    requires_human(action): Mark a test that requires some kind of non-automated action (e.g. closing a GUI window)


### PR DESCRIPTION
This PR addresses PyQt5 errors occurring when invoking `foqus` in GUI mode as described e.g. in #821. Although it was not possible to reproduce the error consistently, the cause seems to be related to the way PyQt5 modules are imported in `foqus_lib.foqus`. This PR adds an explicit import of the required PyQt5 modules in the `guiImport()` function, to make sure that they're properly initialized when the GUI objects are instantiated.

In addition to the changes to the code, I added two tests. Although the conditions under which the original error occurs aren't known precisely, the tests will fail in similar circumstances.

1. Check that it's possible to create a `QApplication` instance after running the `foqus_lib.foqus.guiImport()` function
1. Test that the actual FOQUS GUI window is created when running `foqus_lib.foqus.main` with the appropriate CLI arguments
  - To complete the test, the GUI window must be closed manually
  - This is considered temporary: in the long run, a better automated solution should be used. In the meantime, to avoid causing issues in automated test environments (such as CircleCI) the test is marked so that it will only run if pytest is invoked with the `-m requires_human` option
  - Alternatively, if we decide that the first test is enough, we could get rid of the manual test altogether