### PR TITLE
Make import guard for dmf_lib more specific and disable pylint import-error check

### DIFF
--- a/foqus_lib/gui/model/dmfUploadDialog.py
+++ b/foqus_lib/gui/model/dmfUploadDialog.py
@@ -11,6 +11,7 @@ import logging
 import platform
 import subprocess
 try:
+    # pylint: disable=import-error
     from dmf_lib.dmf_browser import DMFBrowser
     from dmf_lib.dialogs.select_repo_dialog import SelectRepoDialog
     from dmf_lib.dialogs.status_dialog import StatusDialog
@@ -29,7 +30,7 @@ try:
     from dmf_lib.common.common import WIN_PATH_SEPARATOR
     from dmf_lib.common.common import WINDOWS
     useDMF = True
-except:
+except ImportError:
     logging.getLogger("foqus." + __name__)\
         .exception('Failed to import or launch DMFBrowser')
     useDMF = False


### PR DESCRIPTION
This PR is part of the ongoing effort for addressing pylint false-positive errors towards #600.

In this case, the imports within the import guard for `dmf_lib` (`try import ... ; except:`) are reported as `import-error`s by pylint, even though the possible missing import is dealt with correctly at runtime.

The changes in this PR are almost completely pylint-specific: the only modification to the runtime behavior is to use a more specific exception type in the `except` clause, as this is usually the preferred way to implement this type of functionality.