### PR TITLE
Add more imports for surrogate modeling

### DIFF
--- a/foqus_lib/framework/optimizer/SM_Optimizer.py
+++ b/foqus_lib/framework/optimizer/SM_Optimizer.py
@@ -55,6 +55,8 @@ try:
         ConcreteModel,
         PositiveReals,
         value,
+        log,
+        exp
     )
     from pyomo.opt import SolverFactory
     import pyutilib.subprocess.GlobalData


### PR DESCRIPTION
The log and exp functions are used from pyomo imports. With the change in pyomo environ import style, these additional imports are required.