### PR TITLE
Get RTDs to use full width of page

### DIFF
--- a/docs/source/_static/schema.css
+++ b/docs/source/_static/schema.css
@@ -96,3 +96,7 @@ html {
     color: black;
     font-weight: 500;
 }
+
+.wy-nav-content {
+    max-width: none;
+}

--- a/docs/source/_static/schema.css
+++ b/docs/source/_static/schema.css
@@ -23,7 +23,6 @@ html {
 #json-schema ul ul ul ul {
     list-style-type: circle;
 }
-
 #json-schema .type {
     font-style: italic;
     opacity: 0.6;
@@ -96,7 +95,6 @@ html {
     color: black;
     font-weight: 500;
 }
-
 .wy-nav-content {
     max-width: none;
     /* max-width: 95% !important; */

--- a/docs/source/_static/schema.css
+++ b/docs/source/_static/schema.css
@@ -99,4 +99,5 @@ html {
 
 .wy-nav-content {
     max-width: none;
+    /* max-width: 95% !important; */
 }


### PR DESCRIPTION
This should stop (most of) the images in the docs from being resized (on large monitors) as described in PR #889 

Regardless, I think it looks better to use the full width of the browser screen for displaying docs, though I'd like _others to review how this looks_ as it changes **EVERY PAGE** of our docs!

I also just added to all PRs (via a change to the RTDs config) that the docs are built for that PR and a link to that is below as part of all the other tests that are run.