### PR TITLE
Better contact info in docs

### DIFF
--- a/docs/source/chapt_debug/index.rst
+++ b/docs/source/chapt_debug/index.rst
@@ -82,12 +82,4 @@ The following are known unresolved issues:
    TurbineLite port is changed the configuration file that FOQUS uses to
    connect to TurbineLite, must also be changed.
 
-Reporting Issues
-----------------
-
-To report an issue or ask a question, send an email to:
-ccsi-support@acceleratecarboncapture.org or open an issue at:
-https://github.com/CCSI-Toolset/FOQUS
-
-Please include detailed steps on how to reproduce the error, including if
-possible, screenshots and log files.
+.. include:: ../contact.rst

--- a/docs/source/chapt_dev/index.rst
+++ b/docs/source/chapt_dev/index.rst
@@ -79,11 +79,4 @@ To build a local copy of the documentation::
 
 Then open the file ``FOQUS/docs/build/html/index.html`` to view the results.
 
-Developer Details
------------------
-
-More details are listed in our `GitHub Wiki pages <https://github.com/CCSI-Toolset/FOQUS/wiki>`_.
-
-The development team can be contacted via GitHub `Issues
-<https://github.com/CCSI-Toolset/FOQUS/issues>`_, `PRs
-<https://github.com/CCSI-Toolset/FOQUS/pulls>`_ or email: ccsi-support@acceleratecarboncapture.org.
+.. include:: ../contact.rst

--- a/docs/source/contact.rst
+++ b/docs/source/contact.rst
@@ -1,0 +1,27 @@
+Contact and Support
+-------------------
+
+There are multiple ways to contact the development team, get support, file a
+bug, make a feature request and even contribute code changes to FOQUS:
+
+- Send a private email to ccsi-support@acceleratecarboncapture.org for
+  contacting an internal set of developers.
+
+- Subscribe to and send an email to our ccsi-users@acceleratecarboncapture.org
+  public discussion forum to ask a question of the existing user base.
+
+- Use any of the public GitHub features:
+
+  - Read or start a new `Discussion <https://github.com/CCSI-Toolset/FOQUS/discussions>`_
+
+  - Open a new `Issue <https://github.com/CCSI-Toolset/FOQUS/issues>`_ if you
+    believe you've found a bug (please include detailed steps on how to
+    reproduce the error, including if possible, screenshots and log files.)
+    This is also where you can make feature requests.
+
+  - Contribute changes to the FOQUS project by opening a `Pull Request
+    <https://github.com/CCSI-Toolset/FOQUS/pulls>`_
+
+General information about the Carbon Capture Simulation for Industry Impact
+(CCSI\ :sup:`2`) project, of which FOQUS is a part, can be found on the
+https://www.acceleratecarboncapture.org/ web site.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,6 +21,7 @@
     chapt_debug/index
     chapt_dev/index
     references
+    contact
     copyright
 
 FOQUS
@@ -111,3 +112,5 @@ from Carbon Capture Pilot Plant Testing. In: Eden, M.R., Ierapetritou, M.G., Tow
 pp. 283-288.
 
 Additional research work can be found on https://www.acceleratecarboncapture.org/publications 
+
+.. include:: contact.rst


### PR DESCRIPTION
This addresse #771 by creating a new contact page and including it in the top index and in the debug and developer chapters.