### PR TITLE
Make warnings failures for ReadTheDocs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,10 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+    fail_on_warning: true

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 # DATE          = $(shell date +%Y-%m-%d_%H%M%S)
-SPHINXOPTS    = -w sphinx-build.log
+SPHINXOPTS    = -w sphinx-build.log -W --keep-going
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build


### PR DESCRIPTION
This is a small change so that ReadTheDocs will fail if there are any warnings found when generating our documentation.

Adding a .readthedocs.yaml file to set a config option for RTDs to fail if there are any warnings when generating the documentation.  Adding a similar change to the Makefile so the same happens when building the docs locally.