### PR TITLE
Improve naming for GitHub Actions workflows and jobs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Checks
 
 on:
   push:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           pip-install-target: -r requirements-dev.txt
       - name: Set up GUI test environment
-        if: contains(matrix.os, 'ubuntu')
+        if: contains(matrix.os, 'linux')
         run: |
           echo "QT_QPA_PLATFORM=minimal" >> $GITHUB_ENV
       - name: Run GUI tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,9 +24,9 @@ defaults:
     shell: bash -l {0}
 
 jobs:
-  run-tests:
-    name: Run tests (py${{ matrix.python-version }}/${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+  pytest:
+    name: Tests (py${{ matrix.python-version }}/${{ matrix.os }})
+    runs-on: ${{ matrix.os-version }}
     strategy:
       fail-fast: false
       matrix:
@@ -36,9 +36,16 @@ jobs:
           - '3.8'
           # - '3.9'
         os:
-          - ubuntu-20.04
-          - windows-2019
-          - macos-10.15
+          - linux
+          - win64
+          - macos
+        include:
+          - os: macos
+            os-version: macos-10.15
+          - os: linux
+            os-version: ubuntu-20.04
+          - os: win64
+            os-version: windows-2019
     steps:
       - uses: actions/checkout@v2
       - name: Set up Conda
@@ -60,7 +67,7 @@ jobs:
           foqus --load ./examples/test_files/Optimization/Opt_Test_01.foqus --run opt --out test_opt.foqus
   gui-tests:
     name: GUI tests (py${{ matrix.python-version }}/${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os-version }}
     strategy:
       fail-fast: false
       matrix:
@@ -70,9 +77,16 @@ jobs:
           - '3.8'
           # - '3.9'
         os:
-          - ubuntu-20.04
-          - windows-2019
-          - macos-10.15
+          - linux
+          - win64
+          - macos
+        include:
+          - os: macos
+            os-version: macos-10.15
+          - os: linux
+            os-version: ubuntu-20.04
+          - os: win64
+            os-version: windows-2019
     steps:
       - uses: actions/checkout@v2
       - name: Set up Conda


### PR DESCRIPTION
- Enable more readable, "abstract" names for OSes in job matrix (e.g. `linux` instead of `ubuntu-20.04`)
  - Mostly done to have a shorter, more memorable name instead of the OS specifiers required by GitHub
  - This has the added advantage that the "concrete" OS specifiers can be changed without having to update the name in the "Settings > Branch protection > Required checks" panel for the repository
- Use more general name for complete workflow ("Checks" instead of "Tests")

## TODO after merging

- [ ] Update "Settings > Branch protection > Required checks" using new names

