### PR TITLE
Use INFO level if failing to import optional pyomo dependency in SM_Optimizer plugin

### DIFF
--- a/foqus_lib/framework/optimizer/SM_Optimizer.py
+++ b/foqus_lib/framework/optimizer/SM_Optimizer.py
@@ -78,7 +78,7 @@ try:
     from smt.sampling_methods import LHS
     packages_available = True
 except ImportError:
-    logging.getLogger("foqus." + __name__).exception("Failed to import the required packages for SM Optimizer solver")
+    logging.getLogger("foqus." + __name__).info("Failed to import the required packages for SM Optimizer solver")
     packages_available = False
 
 


### PR DESCRIPTION
## Motivation

- pyomo is an optional dependency for the `SM_Optimizer` plugin, but unlike other plugins, the message reporting the unavailability of plugin dependencies is logged as an error
- This causes a false-positive error (FOQUS doesn't crash), which could nonetheless cause some tests to fail (e.g. if the tests look at log output to check for `ERROR` messages) in addition to being confusing

## Changes

- Use `logger.info()` instead of `logger.exception()` to display error message