### PR TITLE
Address CI failures due to pip install job timeouts

### DIFF
--- a/.github/actions/setup-foqus/action.yml
+++ b/.github/actions/setup-foqus/action.yml
@@ -11,6 +11,15 @@ inputs:
 runs:
   using: composite
   steps:
+      # IMPORTANT this requires the Conda env setup to be run before this action
+    - name: Update pip and other packaging tools using Conda
+      # -l: login shell, needed when using Conda run:
+      shell: bash -l {0}
+      run: |
+        echo '::group::Output of "conda install" command'
+        conda install --yes --quiet pip setuptools wheel
+        conda list
+        echo '::endgroup::'
     - name: Install FOQUS and dependencies using pip
       shell: bash -l {0}
       run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,6 +23,10 @@ defaults:
     # the -l flag is needed for the Conda environment to be activated properly
     shell: bash -l {0}
 
+env:
+  FOQUS_CONDA_ENV_NAME_DEV: ccsi-foqus-dev
+  PYTEST_ARTIFACTS_PATH: ".pytest-artifacts"
+
 jobs:
   pytest:
     name: Tests (py${{ matrix.python-version }}/${{ matrix.os }})
@@ -53,7 +57,7 @@ jobs:
       - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v2
         with:
-          activate-environment: ccsi-foqus
+          activate-environment: ${{ env.FOQUS_CONDA_ENV_NAME_DEV }}
           python-version: ${{ matrix.python-version }}
       - name: Set up FOQUS
         uses: ./.github/actions/setup-foqus
@@ -73,6 +77,7 @@ jobs:
       - name: Run FOQUS workflow in batch mode
         run: |
           foqus --load ./examples/test_files/Optimization/Opt_Test_01.foqus --run opt --out test_opt.foqus
+
   gui-tests:
     name: GUI tests (py${{ matrix.python-version }}/${{ matrix.os }})
     runs-on: ${{ matrix.os-version }}
@@ -100,7 +105,7 @@ jobs:
       - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v2
         with:
-          activate-environment: ccsi-foqus
+          activate-environment: ${{ env.FOQUS_CONDA_ENV_NAME_DEV }}
           python-version: ${{ matrix.python-version }}
       - name: Set up FOQUS
         uses: ./.github/actions/setup-foqus
@@ -132,18 +137,35 @@ jobs:
           # - '3.9'
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - name: Set up Conda
+        uses: conda-incubator/setup-miniconda@v2
         with:
+          activate-environment: ${{ env.FOQUS_CONDA_ENV_NAME_DEV }}
           python-version: ${{ matrix.python-version }}
-      - uses: ./.github/actions/pylint
-        name: Run pylint (action)
+      - name: Set up FOQUS
+        uses: ./.github/actions/setup-foqus
+        with:
+          pip-install-target: -r requirements-dev.txt
+      - name: Run pylint
+        run: |
+          pylint --rcfile=.pylint/pylintrc --disable=W,C,R,I foqus_lib/
+
   docs:
     name: Build docs
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - name: Set up Conda
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: '3.7'
-      - uses: ./.github/actions/build-docs
-        name: Build docs (action)
+          activate-environment: ${{ env.FOQUS_CONDA_ENV_NAME_DEV }}
+          python-version: ${{ matrix.python-version }}
+      - name: Set up FOQUS
+        uses: ./.github/actions/setup-foqus
+        with:
+          pip-install-target: -r requirements-dev.txt
+      - name: Build docs
+        run: |
+          cd docs/
+          make CLOPTS="-qW --keep-going" clean dummy
+


### PR DESCRIPTION
## Motivation

- The `build-docs` and `pylint` jobs fail due to repeated timeouts/network errors at the `pip install` stage
- This seems to be due to a failure in pip's dependency solver, causing pip to download multiple versions of the same package from PyPI in rapid succession, leading to the network errors
- The failing jobs were seen in e.g. #916, but most likely they're unrelated to the PR's content
  - Possibly, but not obviously, related to pip-related errors such as e.g. IDAES/idaes-pse#439

## Changes in this PR

- Adopt the same Conda-based strategy already in use for the `pytest` job to setup the environment for the `build-docs` and `pylint` jobs