### PR TITLE
Remove unneeded coveragepy package

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,8 +11,6 @@ pytest
 ### coverage
 coverage
 pytest-cov
-# coveragepy: required for CodeCov upload
-coveragepy
 
 sphinx
 sphinx_rtd_theme


### PR DESCRIPTION
- The PyPI package `coveragepy` (as opposed to the "Coverage.py" package, which is named `coverage` on PyPI) is most likely not needed, and may result in some installation incompatibilities as reported by @anujad95