### PR TITLE
Fixing typo in LaTeX / PDF project name

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,3 +8,6 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
     fail_on_warning: true
+
+# Build all formats
+formats: all

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -282,8 +282,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'FOQUS.tex', u'FOQUS Documentation',
-     u'CCIS team', 'manual'),
+    (master_doc, 'FOQUS.tex', u'FOQUS Documentation', u'CCSI team', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of


### PR DESCRIPTION
The project name, used only in the LaTeX / PDF output from ReadTheDocs was "CCIS" and not "CCSI".  This fixes that typo.

This PR also adds to `.readthedocs.yaml` the directive to build all formats of the docs.  It seems we stopped building the PDF versions when that `.readthedocs.yaml` file was first introduced (leaving 3.9.0, as the latest release with PDF docs).  Unfortunately RTD does not produce the PDF format when building for a PR, so we'll have to merge this to see if it works or not.