### PR TITLE
SDoE: Show/hide table columns dynamically

### DIFF
--- a/foqus_lib/gui/sdoe/sdoeSetupFrame.py
+++ b/foqus_lib/gui/sdoe/sdoeSetupFrame.py
@@ -789,17 +789,11 @@ class sdoeSetupFrame(_sdoeSetupFrame, _sdoeSetupFrameUI):
             msgBox = QMessageBox()
             msgBox.setText(warningMessage)
             msgBox.exec_()
-            self.filesTable.setColumnHidden(5, False)
-            self.filesTable.setColumnHidden(6, False)
-            self.filesTable.setColumnHidden(7, False)
-            self.filesTable.setColumnHidden(8, False)
-            self.filesTable.setColumnHidden(9, False)
+            for i in range(5, 10):
+                self.filesTable.setColumnHidden(i, False)
         else:
-            self.filesTable.setColumnHidden(5, True)
-            self.filesTable.setColumnHidden(6, True)
-            self.filesTable.setColumnHidden(7, True)
-            self.filesTable.setColumnHidden(8, True)
-            self.filesTable.setColumnHidden(9, True)
+            for i in range(5, 10):
+                self.filesTable.setColumnHidden(i, True)
 
         return np.sum(np.isnan(arr[:, 0:-1])) > 0
 

--- a/foqus_lib/gui/sdoe/sdoeSetupFrame.py
+++ b/foqus_lib/gui/sdoe/sdoeSetupFrame.py
@@ -789,6 +789,17 @@ class sdoeSetupFrame(_sdoeSetupFrame, _sdoeSetupFrameUI):
             msgBox = QMessageBox()
             msgBox.setText(warningMessage)
             msgBox.exec_()
+            self.filesTable.setColumnHidden(5, False)
+            self.filesTable.setColumnHidden(6, False)
+            self.filesTable.setColumnHidden(7, False)
+            self.filesTable.setColumnHidden(8, False)
+            self.filesTable.setColumnHidden(9, False)
+        else:
+            self.filesTable.setColumnHidden(5, True)
+            self.filesTable.setColumnHidden(6, True)
+            self.filesTable.setColumnHidden(7, True)
+            self.filesTable.setColumnHidden(8, True)
+            self.filesTable.setColumnHidden(9, True)
 
         return np.sum(np.isnan(arr[:, 0:-1])) > 0
 


### PR DESCRIPTION
Depending on the existence of missing values in the uploaded candidate set, the columns in the **Design Setup** table will show/hide dynamically to avoid user confusion. Should take care of issue #993, suggested by @sspoon 