### PR TITLE
Pin psuade-lite to 1.8 version before #980 is merged

### DIFF
--- a/.github/actions/setup-foqus/action.yml
+++ b/.github/actions/setup-foqus/action.yml
@@ -36,5 +36,5 @@ runs:
       shell: bash -l {0}
       run: |
         echo '::group::Output of "conda install psuade-lite"'
-        conda install --yes --quiet -c CCSI-Toolset -c conda-forge psuade-lite
+        conda install --yes --quiet -c CCSI-Toolset -c conda-forge psuade-lite=1.8
         echo '::endgroup::'

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -63,7 +63,7 @@ jobs:
           echo '::group::Output of conda create/activate/install'
           conda create --name ccsi-foqus --quiet --yes python="$py_ver" pip=21.1
           conda activate ccsi-foqus
-          conda install --yes -c CCSI-Toolset -c conda-forge psuade-lite
+          conda install --yes -c CCSI-Toolset -c conda-forge psuade-lite=1.8
           echo '::endgroup::'
           echo '::group::Output of pip install/list/show'
           pip install --progress-bar off --ignore-installed "$pip_install_target"

--- a/docs/source/chapt_install/install_optional.rst
+++ b/docs/source/chapt_install/install_optional.rst
@@ -20,7 +20,7 @@ analysis, design optimization, model calibration, and more.
 `PSUADE-Lite <https://github.com/LLNL/psuade-lite>`_ is now available as a Conda package. To install just follow the steps below::
 
   conda activate ccsi-foqus
-  conda install --yes -c conda-forge -c CCSI-Toolset psuade-lite
+  conda install --yes -c conda-forge -c CCSI-Toolset psuade-lite=1.8
   psuade --help  # quickly test that the psuade executable has been installed correctly
 
 The ``psuade`` executable should now be available within the Conda environment's folders, i.e. at the path ``$CONDA_PREFIX/bin/psuade`` (Linux, macOS) or ``%CONDA_PREFIX%\bin\psuade.exe`` (Windows).


### PR DESCRIPTION
After the release of LLNL/psuade-lite 1.9, the Conda packages for 1.9 are available on the CCSI-Toolset Anaconda channel. However, psuade-lite 1.9 won't be compatible with FOQUS until #980 is merged, so, in the meantime, I've added a version specifier whenever psuade-lite is installed so that the compatible version is used. Until this PR is merged, tests might start failing (including the nightly builds), therefore I've marked this as high priority.

Once this PR is merged in, @sotorrio1 can test that this works as expected with #980:

- [ ] Merge the changes from `master` into PR #980: the tests should fail (because 1.8 is specified)
- [ ] On the PR #980 branch, pull, then change `psuade-lite=1.8` to `psuade-lite=1.9`, then commit and push the changes: the tests should pass because 1.9 is specified
- [ ] Once #980 is merged in, psuade-lite 1.9 will be used until a new version is released in the future