### PR TITLE
Update requirements for Python version

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -56,10 +56,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.6'
           - '3.7'
           - '3.8'
-          # - '3.9'
+          - '3.9'
         os:
           - linux
           - win64
@@ -124,10 +123,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.6'
           - '3.7'
           - '3.8'
-          # - '3.9'
+          - '3.9'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Conda

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -50,6 +50,7 @@ jobs:
           - foqus-install-target: stable
             os: win64
             python-version: '3.8'
+            hotfix-command: pip install pywin32==225 && pip show pywin32
 
     steps: 
       - name: Set up Conda

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -23,10 +23,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.6'
+          - '3.6'  # TODO remove once support for 3.6 is dropped entirely
           - '3.7'
           - '3.8'
-          # - '3.9'
+          - '3.9'
         os:
           - linux
           - win64

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -50,7 +50,6 @@ jobs:
           - foqus-install-target: stable
             os: win64
             python-version: '3.8'
-            hotfix-command: pip install pywin32==225 && pip show pywin32
 
     steps: 
       - name: Set up Conda

--- a/.pylint/pylintrc
+++ b/.pylint/pylintrc
@@ -1,6 +1,7 @@
 
 [MASTER]
-init-hook="import sys; sys.path.append('.pylint')"
+# https://github.com/PyCQA/pylint/issues/4577
+init-hook="import sys; sys.path.append('.pylint'); import astroid; astroid.context.InferenceContext.max_inferred = 500"
 load-plugins=foqus_transform
 extension-pkg-whitelist=PyQt5
 ignore-patterns=test_*,conftest,

--- a/docs/source/chapt_install/install_python.rst
+++ b/docs/source/chapt_install/install_python.rst
@@ -3,7 +3,7 @@
 Install Python
 --------------
 
-Python version 3.6 up through 3.8 is required to run FOQUS.
+Python version 3.7 up through 3.9 is required to run FOQUS.
 
 We recommend using either the `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ or
 `Anaconda <https://www.anaconda.com/download/>`_ Python distribution and package management
@@ -17,7 +17,7 @@ ability to create self-contained python environments without any need for admini
 privileges. These separate environments can have different set of packages, isolating version
 dependencies when working with multiple python projects.
 
-If you have a working version of Python 3.6 through 3.8, which you prefer over Anaconda, you can
+If you have a working version of Python 3.7 through 3.9, which you prefer over Anaconda, you can
 skip these steps.
 
 Anaconda or Miniconda Install and Setup

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,6 @@ black==21.5b2
 
 # pytest-qt-extras
 pytest-qt==4.0.*
-dataclasses;python_version<"3.7"
 python-slugify
 oyaml
 # singledispatchmethod needed for < 3.8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,11 +2,11 @@
 
 # These will override requirements picked up from setup.py below:
 # pinning the pylint version to ensure reproducible behavior and defaults
-pylint==2.6.0
+pylint
 # also pinning the version for astroid (used by pylint to analyze the AST)
 # since there can be significant differences between (non-major) versions,
 # both in terms of behavior and performance
-astroid==2.4.2
+astroid
 pytest
 ### coverage
 coverage

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,8 @@ dist = setup(
         "numpy",
         "pandas",
         "psutil",
-        "PyQt5==5.13",
+        "PyQt5==5.12.3; sys_platform == 'win32' and python_version >= '3.9'",
+        "PyQt5==5.13; sys_platform != 'win32' or python_version < '3.9'",
         # pinning pywin32 to version 225 as a workaround for Python 3.8 compatibility issues
         # (ImportError: DLL load failed while importing ...)
         # for more information see e.g. https://stackoverflow.com/a/62249872

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ dist = setup(
     maintainer=ver.maintainer,
     maintainer_email=ver.maintainer_email,
     url=ver.webpage,
-    python_requires=">=3.7,<=3.9",
+    python_requires=">=3.7,<3.10",
     packages=find_packages(),
     py_modules=["pytest_qt_extras"],
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ dist = setup(
     maintainer=ver.maintainer,
     maintainer_email=ver.maintainer_email,
     url=ver.webpage,
+    python_requires=">=3.7,<=3.9",
     packages=find_packages(),
     py_modules=["pytest_qt_extras"],
     package_data={

--- a/setup.py
+++ b/setup.py
@@ -100,10 +100,7 @@ dist = setup(
         "pandas",
         "psutil",
         "PyQt5==5.13",
-        # pinning pywin32 to version 225 as a workaround for Python 3.8 compatibility issues
-        # (ImportError: DLL load failed while importing ...)
-        # for more information see e.g. https://stackoverflow.com/a/62249872
-        "pywin32==225; sys_platform == 'win32'",
+        "pywin32; sys_platform == 'win32'",
         "requests",
         "scipy",
         "tqdm",

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,10 @@ dist = setup(
         "pandas",
         "psutil",
         "PyQt5==5.13",
-        "pywin32; sys_platform == 'win32'",
+        # pinning pywin32 to version 225 as a workaround for Python 3.8 compatibility issues
+        # (ImportError: DLL load failed while importing ...)
+        # for more information see e.g. https://stackoverflow.com/a/62249872
+        "pywin32==225; sys_platform == 'win32'",
         "requests",
         "scipy",
         "tqdm",


### PR DESCRIPTION
## Summary/Motivation:

- Update supported Python versions to 3.7 through 3.9
- ~~Remove version constraint for `pywin32` since it shouldn't be needed anymore~~
  - **EDIT**: it seems that removing the constraint results in errors, and therefore we have to keep the `pywin32` version pinned to the older 225

## Changes proposed in this PR:
- Remove Python 3.6 and add 3.9 to CI checks
- Update `setup.py` with Python version requirements and updates

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
