### PR TITLE
Ensure setuptools version compatible with adodbapi is installed

### DIFF
--- a/.github/actions/setup-foqus/action.yml
+++ b/.github/actions/setup-foqus/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash -l {0}
       run: |
         echo '::group::Output of "conda install" command'
-        conda install --yes --quiet -c conda-forge pip
+        conda install --yes --quiet -c conda-forge pip pywin32
         conda list
         echo '::endgroup::'
     - name: Install FOQUS and dependencies using pip

--- a/.github/actions/setup-foqus/action.yml
+++ b/.github/actions/setup-foqus/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash -l {0}
       run: |
         echo '::group::Output of "conda install" command'
-        conda install --yes --quiet pip pywin32
+        conda install --yes --quiet -c conda-forge pip pywin32
         conda list
         echo '::endgroup::'
     - name: Install FOQUS and dependencies using pip

--- a/.github/actions/setup-foqus/action.yml
+++ b/.github/actions/setup-foqus/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash -l {0}
       run: |
         echo '::group::Output of "conda install" command'
-        conda install --yes --quiet -c conda-forge pip pywin32=303
+        conda install --yes --quiet -c conda-forge pip
         conda list
         echo '::endgroup::'
     - name: Install FOQUS and dependencies using pip

--- a/.github/actions/setup-foqus/action.yml
+++ b/.github/actions/setup-foqus/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash -l {0}
       run: |
         echo '::group::Output of "conda install" command'
-        conda install --yes --quiet pip=21.1 setuptools wheel
+        conda install --yes --quiet pip pywin32
         conda list
         echo '::endgroup::'
     - name: Install FOQUS and dependencies using pip

--- a/.github/actions/setup-foqus/action.yml
+++ b/.github/actions/setup-foqus/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash -l {0}
       run: |
         echo '::group::Output of "conda install" command'
-        conda install --yes --quiet -c conda-forge pip pywin32
+        conda install --yes --quiet -c conda-forge pip pywin32=303
         conda list
         echo '::endgroup::'
     - name: Install FOQUS and dependencies using pip

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -56,7 +56,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.6'
           - '3.7'
           - '3.8'
           # - '3.9'
@@ -124,7 +123,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.6'
           - '3.7'
           - '3.8'
           # - '3.9'

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -23,7 +23,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.6'
           - '3.7'
           - '3.8'
           # - '3.9'

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -50,7 +50,6 @@ jobs:
           - foqus-install-target: stable
             os: win64
             python-version: '3.8'
-            hotfix-command: pip install pywin32==225 && pip show pywin32
 
     steps: 
       - name: Set up Conda
@@ -61,7 +60,7 @@ jobs:
           pip_install_target: ${{ matrix.pip-install-target }}
         run: |
           echo '::group::Output of conda create/activate/install'
-          conda create --name ccsi-foqus --quiet --yes python="$py_ver" pip=21.1
+          conda create --name ccsi-foqus --quiet --yes -c conda-forge python="$py_ver" pywin32
           conda activate ccsi-foqus
           conda install --yes -c CCSI-Toolset -c conda-forge psuade-lite=1.9
           echo '::endgroup::'

--- a/docs/source/chapt_dev/index.rst
+++ b/docs/source/chapt_dev/index.rst
@@ -20,7 +20,7 @@ and processes:
 
 - GitHub is where the `FOQUS source code <https://github.com/CCSI-Toolset/FOQUS>`_ resides.
 
-- We make extensive use of GitHub’s `Issue Tracker <https://github.com/CCSI-Toolset/FOQUS/issues>`_
+- We make extensive use of GitHub's `Issue Tracker <https://github.com/CCSI-Toolset/FOQUS/issues>`_
   , `Pull Requests <https://github.com/CCSI-Toolset/FOQUS/pulls>`_ and `Project Boards
   <https://github.com/orgs/CCSI-Toolset/projects>`_ for managing the development tasks using a
   modified Kanban development process.
@@ -28,8 +28,7 @@ and processes:
 - `ReadTheDocs <https://foqus.readthedocs.io>`_ is used to generate and host our on-line
   documentation.
 
-- `CircleCI <https://circleci.com/gh/CCSI-Toolset/FOQUS>`_ and `AppVeyor
-  <https://www.appveyor.com/>`_ are the Continuous Integration system we use.
+- For Continuous Integration (CI) we use `GitHub Actions <https://github.com/CCSI-Toolset/FOQUS/actions>`_.
 
 - `Anaconda <https://www.anaconda.com/distribution/>`_ for isolating Python runtime and development
   environment.

--- a/docs/source/chapt_dev/index.rst
+++ b/docs/source/chapt_dev/index.rst
@@ -43,7 +43,7 @@ will need a copy of the source to work with. Here is rough set of steps to get s
 
 - In a terminal create a conda env in which to work::
 
-    conda create --name ccsi-foqus python=3.8
+    conda create --name ccsi-foqus -c conda-forge python=3.8 pywin32
     conda activate ccsi-foqus
 
 - In a terminal, get the FOQUS source::

--- a/docs/source/chapt_install/index.rst
+++ b/docs/source/chapt_install/index.rst
@@ -16,7 +16,7 @@ FOQUS:
 
   - In a terminal, to setup and install::
       
-      conda create --name ccsi-foqus python=3.8
+      conda create --name ccsi-foqus -c conda-forge python=3.8 pywin32
       conda activate ccsi-foqus
       pip install ccsi-foqus
       foqus --make-shortcut  # Create Desktop shortcut (Windows only)

--- a/docs/source/chapt_install/install_python.rst
+++ b/docs/source/chapt_install/install_python.rst
@@ -37,7 +37,7 @@ Anaconda or Miniconda Install and Setup
    after the `--name` flag in the below command.  In a terminal (or on Windows in the Anaconda
    Prompt) type::
 
-    conda create --name ccsi-foqus python=3.8
+    conda create --name ccsi-foqus -c conda-forge python=3.8 pywin32
 
    Then follow the prompts.  This will create a new conda environment with a minimal set of
    packages.  To use a different version of python, change the version specified after `python=` in

--- a/docs/source/chapt_install/install_python.rst
+++ b/docs/source/chapt_install/install_python.rst
@@ -30,24 +30,24 @@ Anaconda or Miniconda Install and Setup
    <https://conda.io/projects/conda/en/latest/user-guide/install/index.html>`_ for your operating
    system.
 
-3. Create a ccsi-foqus conda environment; this environment will be referred to as "ccsi-foqus" in
+3. Create a ccsi-foqus conda environment; this environment will be referred to as ``ccsi-foqus`` in
    the installation documentation, but you can use any name you like.  If you would like to install
    multiple version of FOQUS (for example a stable version and the latest development version), this
    can be done by running the following command multiple times with different environment names
-   after the `--name` flag in the below command.  In a terminal (or on Windows in the Anaconda
+   after the ``--name`` flag in the below command.  In a terminal (or on Windows in the Anaconda
    Prompt) type::
 
     conda create --name ccsi-foqus -c conda-forge python=3.8 pywin32
 
    Then follow the prompts.  This will create a new conda environment with a minimal set of
-   packages.  To use a different version of python, change the version specified after `python=` in
+   packages.  To use a different version of python, change the version specified after ``python=`` in
    the command.
 
-.. note::
-   The command above installs the ``pywin32`` Conda package immediately after creating the Conda environment.
-   The ``pywin32`` package is strictly required to run FOQUS on Windows, and should be installed with Conda from the ``conda-forge`` channel
-   or errors might occur. For other platforms (Linux, macOS), this is not required. However, the ``pywin32`` package itself is still available,
-   and therefore the command above is compatible with all platform for which FOQUS is supported.
+   .. note::
+      The command above installs the ``pywin32`` Conda package immediately after creating the Conda environment.
+      The ``pywin32`` package is strictly required to run FOQUS on Windows, and should be installed with Conda from the ``conda-forge`` channel
+      or errors might occur. For other platforms (Linux, macOS), the ``pywin32`` package is not required. However, the ``pywin32`` package itself is still available,
+      and therefore the command above is compatible with all platforms for which FOQUS is supported.
 
 4. Activate the environment on Linux in a terminal type::
 

--- a/docs/source/chapt_install/install_python.rst
+++ b/docs/source/chapt_install/install_python.rst
@@ -43,6 +43,12 @@ Anaconda or Miniconda Install and Setup
    packages.  To use a different version of python, change the version specified after `python=` in
    the command.
 
+.. note::
+   The command above installs the ``pywin32`` Conda package immediately after creating the Conda environment.
+   The ``pywin32`` package is strictly required to run FOQUS on Windows, and should be installed with Conda from the ``conda-forge`` channel
+   or errors might occur. For other platforms (Linux, macOS), this is not required. However, the ``pywin32`` package itself is still available,
+   and therefore the command above is compatible with all platform for which FOQUS is supported.
+
 4. Activate the environment on Linux in a terminal type::
 
     conda activate ccsi-foqus

--- a/docs/source/chapt_install/install_python.rst
+++ b/docs/source/chapt_install/install_python.rst
@@ -3,7 +3,7 @@
 Install Python
 --------------
 
-Python version 3.6 up through 3.8 is required to run FOQUS.
+Python version 3.7 up through 3.8 is required to run FOQUS.
 
 We recommend using either the `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ or
 `Anaconda <https://www.anaconda.com/download/>`_ Python distribution and package management
@@ -17,7 +17,7 @@ ability to create self-contained python environments without any need for admini
 privileges. These separate environments can have different set of packages, isolating version
 dependencies when working with multiple python projects.
 
-If you have a working version of Python 3.6 through 3.8, which you prefer over Anaconda, you can
+If you have a working version of Python 3.7 through 3.8, which you prefer over Anaconda, you can
 skip these steps.
 
 Anaconda or Miniconda Install and Setup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,0 @@
-[build-system]
-requires = ["setuptools<58; sys_platform == 'win32'"]
-build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
 requires = ["setuptools<58; sys_platform == 'win32'"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools<58; sys_platform == 'win32'"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,7 +15,6 @@ black==22.3.0
 
 # pytest-qt-extras
 pytest-qt==4.0.*
-dataclasses;python_version<"3.7"
 python-slugify
 oyaml
 # singledispatchmethod needed for < 3.8

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ dist = setup(
         "pandas",
         "psutil",
         "PyQt5==5.13",
-        "pywin32; sys_platform == 'win32'",
+        "pywin32==227; sys_platform == 'win32'",
         "requests",
         "scipy",
         "tqdm",

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ dist = setup(
     },
     # Required packages needed in the users env go here (non-versioned strongly preferred).
     # requirements.txt should stay empty (other than the "-e .")
-    setup_requires=[
+    build_requires=[
         "setuptools<58; sys_platform == 'win32'",
     ],
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -100,10 +100,7 @@ dist = setup(
         "pandas",
         "psutil",
         "PyQt5==5.13",
-        # pinning pywin32 to version 225 as a workaround for Python 3.8 compatibility issues
-        # (ImportError: DLL load failed while importing ...)
-        # for more information see e.g. https://stackoverflow.com/a/62249872
-        "pywin32==225; sys_platform == 'win32'",
+        "pywin32; sys_platform == 'win32'",
         "requests",
         "scipy",
         "tqdm",

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,6 @@ dist = setup(
     # Required packages needed in the users env go here (non-versioned strongly preferred).
     # requirements.txt should stay empty (other than the "-e .")
     install_requires=[
-        "adodbapi>=2.6.0.7; sys_platform == 'win32'",
         "boto3",
         "cma",
         "matplotlib",

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,9 @@ dist = setup(
     },
     # Required packages needed in the users env go here (non-versioned strongly preferred).
     # requirements.txt should stay empty (other than the "-e .")
+    setup_requires=[
+        "setuptools<58; sys_platform == 'win32'",
+    ],
     install_requires=[
         "adodbapi>=2.6.0.7; sys_platform == 'win32'",
         "boto3",

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ dist = setup(
         "pandas",
         "psutil",
         "PyQt5==5.13",
-        "pywin32==227; sys_platform == 'win32'",
+        "pywin32; sys_platform == 'win32'",
         "requests",
         "scipy",
         "tqdm",

--- a/setup.py
+++ b/setup.py
@@ -89,9 +89,6 @@ dist = setup(
     },
     # Required packages needed in the users env go here (non-versioned strongly preferred).
     # requirements.txt should stay empty (other than the "-e .")
-    build_requires=[
-        "setuptools<58; sys_platform == 'win32'",
-    ],
     install_requires=[
         "adodbapi>=2.6.0.7; sys_platform == 'win32'",
         "boto3",


### PR DESCRIPTION
## Fixes: #1022

## Summary/Motivation:
- Fix errors when running `pip install` on Windows

## Changes proposed in this PR:
- Add version constraint for `setuptools<58` so that `build_py_2to3` is still available

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
