### PR TITLE
Switch PyQt5 requirement to 5.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ dist = setup(
         "numpy",
         "pandas",
         "psutil",
-        "PyQt5==5.13",
+        "PyQt5==5.12.*",
         "pywin32; sys_platform == 'win32'",
         "requests",
         "scipy",


### PR DESCRIPTION
## Fixes/Addresses: #1016

## Summary/Motivation

- PyQt 5.12.3 is the latest version that can be installed via Conda

## Changes proposed in this PR:
- Update the version requirement for PyQt to `PyQt5==5.12.*`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
