### PR TITLE
Add support for Python 3.9 and 3.10

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -58,7 +58,8 @@ jobs:
         python-version:
           - '3.7'
           - '3.8'
-          # - '3.9'
+          - '3.9'
+          - '3.10'
         os:
           - linux
           - win64
@@ -125,7 +126,8 @@ jobs:
         python-version:
           - '3.7'
           - '3.8'
-          # - '3.9'
+          - '3.9'
+          - '3.10'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Conda

--- a/.pylint/foqus_transform.py
+++ b/.pylint/foqus_transform.py
@@ -43,6 +43,7 @@ def get_pyqtsignal_classdef(context=None):
 PYQTSIGNAL_ATTRIBUTE_NAMES = frozenset(
     [
         "currentIndexChanged",
+        "valueChanged",
     ]
 )
 

--- a/docs/source/chapt_install/install_python.rst
+++ b/docs/source/chapt_install/install_python.rst
@@ -3,7 +3,7 @@
 Install Python
 --------------
 
-Python version 3.7 up through 3.8 is required to run FOQUS.
+Python version 3.7 up through 3.10 is required to run FOQUS.
 
 We recommend using either the `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ or
 `Anaconda <https://www.anaconda.com/download/>`_ Python distribution and package management
@@ -17,7 +17,7 @@ ability to create self-contained python environments without any need for admini
 privileges. These separate environments can have different set of packages, isolating version
 dependencies when working with multiple python projects.
 
-If you have a working version of Python 3.7 through 3.8, which you prefer over Anaconda, you can
+If you have a working version of Python 3.7 through 3.10, which you prefer over Anaconda, you can
 skip these steps.
 
 Anaconda or Miniconda Install and Setup

--- a/foqus_lib/framework/graph/graph.py
+++ b/foqus_lib/framework/graph/graph.py
@@ -940,7 +940,7 @@ class Graph(threading.Thread):
             else:
                 newGr.res_re = resubs
         else:
-            raise ("Must supply runList or jobIds")
+            raise ValueError("Must supply runList or jobIds")
         newGr.status = {
             "unfinished": len(newGr.res),
             "finished": 0,

--- a/foqus_lib/framework/listen/listen.py
+++ b/foqus_lib/framework/listen/listen.py
@@ -187,6 +187,9 @@ class foqusListener(threading.Thread):
                     self.gt.join()
                     ret = []
                     stat = []
+                    # WHY pylint infers `res` as an unsubscriptable object
+                    # (possibly because of None default value?)
+                    # pylint: disable=unsubscriptable-object
                     for res in self.gt.res:
                         self.dat.flowsheet.results.addFromSavedValues(
                             self.resStoreSet, "res_{0}".format(self.runid), None, res
@@ -203,6 +206,7 @@ class foqusListener(threading.Thread):
                             for i in range(len(r)):
                                 r[i] = self.failValue
                         ret.append(r)
+                    # pylint: enable=unsubscriptable-object
                     conn.send(["result", stat, ret])
                 elif msg[0] == "save":
                     # Save the flow sheet

--- a/foqus_lib/framework/sdoe/irsf.py
+++ b/foqus_lib/framework/sdoe/irsf.py
@@ -188,7 +188,10 @@ def criterion(cand, args, nr, nd, mode="maximin", hist=None, test=False):
     PV_tuple = ()
     for key in PV:
         if len(PV[key].shape) == 1:
+            # WHY: causes `modified-iterating-dict` in pylint 2.14.1
+            # pylint: disable=modified-iterating-dict
             PV[key] = np.expand_dims(PV[key], axis=0)
+            # pylint: enable=modified-iterating-dict
         PV_tuple += (PV[key],)
     PV_arr = np.concatenate(PV_tuple, axis=0)
     PV_df = pd.DataFrame(data=PV_arr, columns=["Best Input", "Best Response"])

--- a/foqus_lib/framework/sim/turbineConfiguration.py
+++ b/foqus_lib/framework/sim/turbineConfiguration.py
@@ -231,6 +231,10 @@ class TurbineConfiguration:
         self.aspenVersion = 2
         self.dat = None
         self.tldb = None
+        # WHY: setting these directly in makeCopy without defining them as attributes here
+        # triggers no-member errors in pylint 2.14.1
+        self.configExt = None
+        self.subDir = None
 
     @property
     def notification(self):

--- a/foqus_lib/framework/uq/Model.py
+++ b/foqus_lib/framework/uq/Model.py
@@ -104,6 +104,7 @@ Methods:
         Gets the filename of the driver or emulator
 """
 
+import collections.abc
 import numbers, json
 import numpy
 
@@ -272,9 +273,8 @@ class Model:
         return self.emulatorOutputStatus
 
     def setEmulatorOutputStatus(self, outputIds, value):
-        import collections
 
-        if isinstance(outputIds, collections.Sequence):  # Check if list or tuple
+        if isinstance(outputIds, collections.abc.Sequence):  # Check if list or tuple
             for outputId in outputIds:
                 self.emulatorOutputStatus[outputId] = value
         else:

--- a/foqus_lib/gui/model/dmfUploadDialog.py
+++ b/foqus_lib/gui/model/dmfUploadDialog.py
@@ -356,7 +356,7 @@ class dmfUploadDialog(_dmfUploadDialog, _dmfUploadDialogUI):
                         self.files[1] = ["model", m_path]
                     self.updateFileTable()
                     self.appEdit.setText(a)
-                except:
+                except Exception as e:
                     QMessageBox.information(self, "Error", str(e))
                     logging.getLogger("foqus." + __name__).exception(
                         "Error reading sinter config"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,11 +2,11 @@
 
 # These will override requirements picked up from setup.py below:
 # pinning the pylint version to ensure reproducible behavior and defaults
-pylint==2.6.0
+pylint==2.14.1
 # also pinning the version for astroid (used by pylint to analyze the AST)
 # since there can be significant differences between (non-major) versions,
 # both in terms of behavior and performance
-astroid==2.4.2
+astroid==2.11.6
 pytest
 ### coverage
 coverage


### PR DESCRIPTION
## Summary

- Support for Python versions 3.9 and 3.10 is important since 3.10 is now the default version in many environments including e.g. Conda

## Changes proposed in this PR:

- Update pylint version to better 3.9 and 3.10 support
- Resolve pylint errors in current codebase by applying minor changes and `disable` pragmas
- Add 3.9 and 3.10 to CI job matrixes and installation docs

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
