### PR TITLE
Update `pytest-qt` to resolve `ModuleNotFoundError:`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@
 pylint==2.14.1
 # also pinning the version for astroid (used by pylint to analyze the AST)
 # since there can be significant differences between (non-major) versions,
-# both in terms of behavior and performance
+# both in terms of behavior and performance 
 astroid==2.11.6
 pytest
 ### coverage

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@
 pylint==2.14.1
 # also pinning the version for astroid (used by pylint to analyze the AST)
 # since there can be significant differences between (non-major) versions,
-# both in terms of behavior and performance 
+# both in terms of behavior and performance
 astroid==2.11.6
 pytest
 ### coverage
@@ -14,7 +14,7 @@ pytest-cov
 black==22.3.0
 
 # pytest-qt-extras
-pytest-qt==4.0.*
+pytest-qt==4.2.*
 python-slugify
 oyaml
 # singledispatchmethod needed for < 3.8


### PR DESCRIPTION
## Fixes/Addresses:

## Summary/Motivation:


## Changes proposed in this PR:
- Recently, `pytest-qt` removed support for the package `py` which broke our CI runs
- This re-pins the package from 4.0.* to 4.2.* to resolve the issue

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
