### PR TITLE
Remove calls to pytest.importorskip() from session-scoped fixtures

### DIFF
--- a/foqus_lib/conftest.py
+++ b/foqus_lib/conftest.py
@@ -115,8 +115,6 @@ def install_plugin_model_files(
 def foqus_ml_ai_models_dir(
     foqus_working_dir: Path,
 ) -> Path:
-    # skip this test if tensorflow is not available
-    pytest.importorskip("tensorflow", reason="tensorflow not installed")
 
     return foqus_working_dir / "user_ml_ai_models"
 
@@ -132,8 +130,6 @@ def install_ml_ai_model_files(
     This is a session-level fixture with autouse b/c it needs to be created
     before the main window is instantiated.
     """
-    # skip this test if tensorflow is not available
-    pytest.importorskip("tensorflow", reason="tensorflow not installed")
 
     print("installing ml_ai model files")
     models_dir = foqus_ml_ai_models_dir


### PR DESCRIPTION
## Resolves: #1107 

## Summary/Motivation

- [`pytest.importorskip("my_module")`](https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest-importorskip) causes tests to be skipped if `my_module` can't be imported
- This is used in FOQUS to account for tests that require optional dependencies such as `tensorflow`
- However, because of a subtlety of its implementation (basically it raises a special exception), if `pytest.importorskip()` is used within a session-scoped fixture (as opposed to inside a test function, or at the top of a test module e.g. `test_my_optional_feature.py`), it will cause *all* tests to be skipped since session-scoped fixture functions are run before any other fixture or test

## Changes proposed in this PR:
- Remove calls to `pytest.importorskip()` from session-scoped fixtures

## How to check that this works?

- In our GitHub Actions workflow, the optional dependencies are only installed for some of the OS/Python version job matrix combinations (namely, they're installed on Python 3.8, and not installed on Python 3.9, with the choice being essentially arbitrary)
- By selecting a Python 3.9 run (i.e. where the ML/AI optional dependencies are not available) we see that only some of the tests are skipped, as opposed to all tests being skipped as reported in #1107

![image](https://user-images.githubusercontent.com/48035537/219079214-c26cb29b-bc49-48f1-8cfb-80c648f67fcd.png)


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
