### PR TITLE
Add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.1.0
+    hooks:
+    - id: black
+      language_version: python3
+      types:
+        - python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3

--- a/docs/source/chapt_dev/index.rst
+++ b/docs/source/chapt_dev/index.rst
@@ -58,6 +58,31 @@ will need a copy of the source to work with. Here is rough set of steps to get s
     pip install -r requirements-dev.txt  # This will pick up both user and developer required packages.
     foqus  # Start the app
 
+Pre-commit hooks (optional, but recommended)
+--------------------------------------------
+
+`Pre-commit hooks <https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks>`_ are scripts that are automatically run by Git "client-side" (i.e. on a developer's local machine)
+whenever ``git commit`` is run. If the pre-commit scripts terminates with an error, the commit will be interrupted,
+requiring the developer to address the failure before being able to complete the commit.
+
+.. note:: This is different (and complementary to) "server-side" checks, i.e. scripts that check the code on the side of the Git remote
+   *after* the code is committed and pushed, such as the Continuous Integration (CI) suite triggered whenever a commit is pushed to an open PR
+   in the FOQUS GitHub repository.
+
+Pre-commit checks are especially useful to ensure that the code is formatted correctly *before* it is pushed to the FOQUS GitHub repository, which otherwise typically would
+cause the developer to 1) be notified by the failing CI check that the code wasn't formatted; 2) run the formatter manually; 3) create a new commit with the formatting changes; 4)
+push the formatted code again.
+
+FOQUS uses the `pre-commit <https://pre-commit.com/>`_ framework to manage a few hooks that are useful for FOQUS developers.
+
+The ``pre-commit`` command is already installed as part of FOQUS's developer dependencies.
+However, the pre-commit *checks* (i.e. the actual scripts that Git will be running) must be installed (using ``pre-commit install``) as a separate step whenever the FOQUS repository is cloned:
+
+   .. code-block:: shell
+
+     pre-commit install
+
+For more information, refer to the `pre-commit "Quick Start" page <https://pre-commit.com/#quick-start>`_.
 
 Run Tests
 ---------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,5 +28,8 @@ sphinx_rtd_theme
 # docutils<0.16,>=0.10 constraint
 docutils<0.16
 
+# manage pre-commit hooks
+pre-commit
+
 # Pick up requirements from setup.py
 -e .

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ pytest
 ### coverage
 coverage
 pytest-cov
-black==22.3.0
+black==23.1.0
 addheader==0.3.2
 
 # pytest-qt-extras

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ pytest
 ### coverage
 coverage
 pytest-cov
-black==23.1.0
+black==22.3.0
 addheader==0.3.2
 
 # pytest-qt-extras


### PR DESCRIPTION
## Summary/Motivation:

The `pre-commit` framework allows to specify arbitrary checks to be run automatically "client-side" whenever `git commit` is executed. This is especially useful to format the code automatically before it's even pushed to the FOQUS GitHub repository.

## Changes proposed in this PR:

- Add `pre-commit` config file
  - For the moment, the only enabled check is `black` code formatting
- Specify `pre-commit` as a dev dependency
- Add text about pre-commit checks in the developer section of the Sphinx docs

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
