### PR TITLE
Set psuade default location with shutil

### DIFF
--- a/foqus_lib/framework/session/session.py
+++ b/foqus_lib/framework/session/session.py
@@ -770,7 +770,10 @@ class generalSettings:
         self.working_dir = ""
         self.new_working_dir = ""
         self.simsinter_path = "C:/Program Files (x86)/CCSI/SimSinter"
-        self.psuade_path = shutil.which("psuade") or "C:/Program Files (x86)/psuade_project 1.7.5/bin/psuade.exe"
+        self.psuade_path = (
+            shutil.which("psuade")
+            or "C:/Program Files (x86)/psuade_project 1.7.5/bin/psuade.exe"
+        )
         self.turbConfig = "turbine.cfg"
         self.turbConfigCluster = "turbine_aws.cfg"
         self.alamo_path = ""

--- a/foqus_lib/framework/session/session.py
+++ b/foqus_lib/framework/session/session.py
@@ -770,7 +770,7 @@ class generalSettings:
         self.working_dir = ""
         self.new_working_dir = ""
         self.simsinter_path = "C:/Program Files (x86)/CCSI/SimSinter"
-        self.psuade_path = "C:/Program Files (x86)/psuade_project 1.7.5/bin/psuade.exe"
+        self.psuade_path = shutil.which("psuade") or "C:/Program Files (x86)/psuade_project 1.7.5/bin/psuade.exe"
         self.turbConfig = "turbine.cfg"
         self.turbConfigCluster = "turbine_aws.cfg"
         self.alamo_path = ""


### PR DESCRIPTION
## Summary/Motivation:
Sets default location for psuade executable if found in the environment


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
