### PR TITLE
Update intersphinx_mapping to non-deprecated format

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -379,7 +379,7 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/": None}
+intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 
 rst_epilog = """
 .. |examples_reminder_text| replace:: The **examples/** directory refers to the location where the FOQUS examples were installed, as described in :ref:`install_examples`.


### PR DESCRIPTION
## Summary/Motivation:

Sphinx 6.2 introduced a deprecation for the format we have been using for `intersphinx_mapping` in `conf.py` (see https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html#confval-intersphinx_mapping, "Old format for this config value"). This, in turn, causes the "Build Sphinx docs" CI job to fail.

## Changes proposed in this PR:

- Update `intersphinx_mapping` to use the non-deprecated version.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
