### PR TITLE
Update macOS GHA runner image to macos-12

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -65,7 +65,7 @@ jobs:
           - macos
         include:
           - os: macos
-            os-version: macos-10.15
+            os-version: macos-12
           - os: linux
             os-version: ubuntu-20.04
           - os: win64

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -37,7 +37,7 @@ jobs:
           - '3.9.0'
         include:
           - os: macos
-            os-version: macos-10.15
+            os-version: macos-12
           - os: linux
             os-version: ubuntu-20.04
           - os: win64


### PR DESCRIPTION
## Fixes/Addresses

- CI failures due to `macos-10.15` runners being unavailable, most likely because that version is outdated

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
