### PR TITLE
Changes to allow install for arm64 darwin.

### DIFF
--- a/docs/source/chapt_install/index.rst
+++ b/docs/source/chapt_install/index.rst
@@ -9,6 +9,10 @@ optional components for use within FOQUS.
 Quick Start
 -----------
 
+.. note::
+    If you are installing on Apple silicon please use the 
+    sub-sections as this quick start will not work.
+
 For those familiar with the details, here is a summary of how to install and run
 FOQUS:
 
@@ -21,6 +25,8 @@ FOQUS:
       pip install ccsi-foqus
       foqus --make-shortcut  # Create Desktop shortcut (Windows only)
 
+  - 
+  
   - In a terminal, to run::
       
       conda activate ccsi-foqus

--- a/docs/source/chapt_install/install_foqus.rst
+++ b/docs/source/chapt_install/install_foqus.rst
@@ -5,7 +5,7 @@ Install FOQUS
 
 .. note::
    In previous releases we instructed you to download the FOQUS code and install it in place.  As
-   of version 1.5.0, this is no longer required.  The below ``pip install`` method is now the
+   of version 1.5.0, this is no longer required unless you are running on Apple silicon.  The below ``pip install`` method is now the
    preferred method to install FOQUS.
 
 To install FOQUS, open the Anaconda prompt (or appropriate terminal or shell depending on operating
@@ -18,3 +18,14 @@ system and choice of Python), and run the following commands::
 This will install FOQUS and all the required packages into the ``ccsi-foqus`` conda environment.
 The last command there will create a Desktop shortcut for easier, non-terminal, startup of FOQUS
 (Windows only, for now).
+
+For Apple silicon
+-----------------
+
+Open the Anaconda prompt and run the following commands::
+
+    conda activate ccsi-foqus
+    conda install pyqt
+    git clone https://github.com/CCSI-Toolset/FOQUS
+    cd FOQUS
+    pip install -e .

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ dist = setup(
         "numpy",
         "pandas",
         "psutil",
-        "PyQt5==5.15.7; platform_machine != 'arm64'",
+        "PyQt5==5.15.7; platform_machine != 'arm64' and sys_platform == 'darwin'",
         "pywin32<305; sys_platform == 'win32'",
         "requests",
         "scipy",

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ dist = setup(
         "numpy",
         "pandas",
         "psutil",
-        "PyQt5==5.15.7; platform_machine != 'arm64' and sys_platform == 'darwin'",
+        "PyQt5==5.15.7; platform_machine != 'arm64' or sys_platform != 'darwin'",
         "pywin32<305; sys_platform == 'win32'",
         "requests",
         "scipy",

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ dist = setup(
         "numpy",
         "pandas",
         "psutil",
-        "PyQt5==5.15.7",
+        "PyQt5==5.15.7; platform_machine != 'arm64'",
         "pywin32<305; sys_platform == 'win32'",
         "requests",
         "scipy",


### PR DESCRIPTION
## Fixes/Addresses:

#1100

## Summary/Motivation:

Allows users of MacOs on Apple silicon to install and run FOQUS.

## Changes proposed in this PR:
- update to setup.py to exclude PyQt5 install on these machines
- documentation of steps required to install on these machines (once we have the next release out we can remove the need to download source as part of this)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
