### PR TITLE
Add NLOpt installation instructions back

### DIFF
--- a/docs/source/chapt_install/install_optional.rst
+++ b/docs/source/chapt_install/install_optional.rst
@@ -66,10 +66,10 @@ Download ALAMO and request a license from the `ALAMO download page
 Install NLopt
 ^^^^^^^^^^^^^
 
-NLopt is an optional optimization library, which can be used by FOQUS. NLopt is not available to be installed with pip, but can be installed with conda as follows:
+NLopt is an optional optimization library, which can be used by FOQUS. NLopt is not available to be installed with pip, but can be installed with conda as follows::
 
-  conda activate ccsi-foqus
-  conda install -c conda-forge nlopt
+    conda activate ccsi-foqus
+    conda install -c conda-forge nlopt
 
 For more information, see the `NLopt Installation Instructions <https://nlopt.readthedocs.io/en/latest/>`_.
 

--- a/docs/source/chapt_install/install_optional.rst
+++ b/docs/source/chapt_install/install_optional.rst
@@ -66,9 +66,13 @@ Download ALAMO and request a license from the `ALAMO download page
 Install NLopt
 ^^^^^^^^^^^^^
 
-NLopt is an optional optimization library, which can be used by FOQUS. NLopt is included in the conda psuade-lite 1.9.0 package.
+NLopt is an optional optimization library, which can be used by FOQUS. NLopt is not available to be installed with pip, but can be installed with conda as follows:
+
+  conda activate ccsi-foqus
+  conda install -c conda-forge nlopt
 
 For more information, see the `NLopt Installation Instructions <https://nlopt.readthedocs.io/en/latest/>`_.
+
 
 Install SnobFit
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Fixes/Addresses:
https://github.com/CCSI-Toolset/FOQUS/issues/1174


## Summary/Motivation:
NLOpt isn't in psuade-lite:1.9 
but documentation claims it is.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
