### PR TITLE
Add new mandatory sections to ReadTheDocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# the build.os and build.tools section is mandatory
+build:
+  os: ubuntu-20.04  # for consistency, matches the one used for CI
+  tools:
+    python: "3.9"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
     fail_on_warning: true


### PR DESCRIPTION
## Resolves #1176

## Changes proposed in this PR:

- Add `build.os` and `build.tools` section to `.readthedocs.yaml`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
