### PR TITLE
parallelize USF and NUSF algorithms using Dask

### DIFF
--- a/foqus_lib/foqus.py
+++ b/foqus_lib/foqus.py
@@ -348,7 +348,18 @@ def main(args_to_parse=None):
     parser.add_argument(
         "-s", "--runUITestScript", help="Load and run a user interface test script"
     )
+    parser.add_argument(
+        "--sdoe_use_dask",
+        action="store_true",
+        help="Use Dask for parallelizing SDoE calculations",
+    )
+
     args = parser.parse_args(args=args_to_parse)
+    if args.sdoe_use_dask:
+        from dask.distributed import Client
+
+        Client()  # n_workers=4, threads_per_worker=1)
+
     # before changing the directory get absolute path for file to load
     # this way it will be relative to where you execute foqus instead
     # or relative to the working dir

--- a/foqus_lib/foqus.py
+++ b/foqus_lib/foqus.py
@@ -356,9 +356,11 @@ def main(args_to_parse=None):
 
     args = parser.parse_args(args=args_to_parse)
     if args.sdoe_use_dask:
+        import dask.config as dconf
         from dask.distributed import Client
 
         Client()  # n_workers=4, threads_per_worker=1)
+        dconf.set({"dataframe.convert-string": False})
 
     # before changing the directory get absolute path for file to load
     # this way it will be relative to where you execute foqus instead

--- a/foqus_lib/foqus.py
+++ b/foqus_lib/foqus.py
@@ -349,9 +349,10 @@ def main(args_to_parse=None):
         "-s", "--runUITestScript", help="Load and run a user interface test script"
     )
     parser.add_argument(
-        "--sdoe_use_dask",
+        "--sdoe-use-dask",
         action="store_true",
         help="Use Dask for parallelizing SDoE calculations",
+        dest="sdoe_use_dask",
     )
 
     args = parser.parse_args(args=args_to_parse)

--- a/foqus_lib/framework/sdoe/nusf.py
+++ b/foqus_lib/framework/sdoe/nusf.py
@@ -307,7 +307,6 @@ def criterion(
             np.concatenate((cand_np_, hist.to_numpy())), idx_np
         )
 
-
     rand_gen = np.random.default_rng(rand_seed)
 
     def step(mwr: int) -> Dict:

--- a/foqus_lib/framework/sdoe/nusf.py
+++ b/foqus_lib/framework/sdoe/nusf.py
@@ -13,7 +13,7 @@
 # "https://github.com/CCSI-Toolset/FOQUS".
 #################################################################################
 import time
-from typing import Optional, Tuple, List, Dict, TypedDict
+from typing import Dict, List, Optional, Tuple, TypedDict, Union
 
 import numpy as np
 import pandas as pd  # only used for the final output of criterion
@@ -60,7 +60,7 @@ def update_min_dist(
     mties: int,
     dmat: np.ndarray,
     hist: np.ndarray,
-    rand_seed: int | None,
+    rand_seed: Union[int, None],
 ) -> Tuple[
     np.ndarray, float, np.ndarray, int, np.ndarray, Optional[int], Optional[int], bool
 ]:
@@ -274,7 +274,7 @@ def criterion(
     nd: int,  # design size <= len(candidates)
     mode: str = "maximin",
     hist: Optional[pd.DataFrame] = None,
-    rand_seed: int | None = None,
+    rand_seed: Union[int, None] = None,
 ) -> Dict:
     ncand = len(cand)
     if hist is not None:

--- a/foqus_lib/framework/sdoe/nusf.py
+++ b/foqus_lib/framework/sdoe/nusf.py
@@ -60,7 +60,7 @@ def update_min_dist(
     mties: int,
     dmat: np.ndarray,
     hist: np.ndarray,
-    rand_seed,
+    rand_seed: int | None,
 ) -> Tuple[
     np.ndarray, float, np.ndarray, int, np.ndarray, Optional[int], Optional[int], bool
 ]:
@@ -274,7 +274,7 @@ def criterion(
     nd: int,  # design size <= len(candidates)
     mode: str = "maximin",
     hist: Optional[pd.DataFrame] = None,
-    rand_seed=None,
+    rand_seed: int | None = None,
 ) -> Dict:
     ncand = len(cand)
     if hist is not None:

--- a/foqus_lib/framework/sdoe/nusf_dask.py
+++ b/foqus_lib/framework/sdoe/nusf_dask.py
@@ -13,7 +13,7 @@
 # "https://github.com/CCSI-Toolset/FOQUS".
 #################################################################################
 import time
-from typing import Optional, Tuple, List, Dict, TypedDict
+from typing import Dict, List, Optional, Tuple, TypedDict, Union
 
 import dask.bag as db
 import numpy as np
@@ -41,7 +41,7 @@ def criterion(
     nd: int,  # design size <= len(candidates)
     mode: str = "maximin",
     hist: Optional[pd.DataFrame] = None,
-    rand_seed: int | None = None,
+    rand_seed: Union[int, None] = None,
 ) -> Dict:
 
     ncand = len(cand)
@@ -77,7 +77,7 @@ def criterion(
 
     rand_gen = np.random.default_rng(rand_seed)
 
-    def step(mwr_tuple: Tuple[int, [int], np.ndarray, np.ndarray | None]) -> Dict:
+    def step(mwr_tuple: Tuple[int, [int], np.ndarray, Union[np.ndarray, None]]) -> Dict:
         mwr, rands, cand_np, hist_np = mwr_tuple
 
         best_cand = []

--- a/foqus_lib/framework/sdoe/nusf_dask.py
+++ b/foqus_lib/framework/sdoe/nusf_dask.py
@@ -77,7 +77,9 @@ def criterion(
 
     rand_gen = np.random.default_rng(rand_seed)
 
-    def step(mwr_tuple: Tuple[int, [int], np.ndarray, Union[np.ndarray, None]]) -> Dict:
+    def step(
+        mwr_tuple: Tuple[int, List[int], np.ndarray, Union[np.ndarray, None]]
+    ) -> Dict:
         mwr, rands, cand_np, hist_np = mwr_tuple
 
         best_cand = []

--- a/foqus_lib/framework/sdoe/sdoe.py
+++ b/foqus_lib/framework/sdoe/sdoe.py
@@ -122,7 +122,10 @@ def run(config_file, nd, test=False):
             "mwr_values": mwr_values,
             "scale_method": scale_method,
         }
-        from .nusf import criterion
+        if use_dask:
+            from .nusf_dask import criterion
+        else:
+            from .nusf import criterion
 
     if sf_method == "usf":
         scl = np.array([ub - lb for ub, lb in zip(max_vals, min_vals)])
@@ -173,12 +176,14 @@ def run(config_file, nd, test=False):
             # pylint: enable=unexpected-keyword-arg
             return results["t1"], results["t2"]
         else:
-            results = criterion(cand, args, nr, nd, mode=mode, hist=hist)
+            t0 = time.time()
+            criterion(cand, args, nr, nd, mode=mode, hist=hist)
+            elapsed_time = time.time() - t0
             if use_dask:
                 return (
-                    results["elapsed_time"] - 1.4
+                    elapsed_time - 1.4
                 )  # Dask startup skews the test results so remove that
-            return results["elapsed_time"]
+            return elapsed_time
 
     # otherwise, run sdoe for real
     t0 = time.time()

--- a/foqus_lib/framework/sdoe/sdoe.py
+++ b/foqus_lib/framework/sdoe/sdoe.py
@@ -13,6 +13,7 @@
 # "https://github.com/CCSI-Toolset/FOQUS".
 #################################################################################
 import configparser
+import logging
 import os
 import platform
 import re
@@ -92,6 +93,9 @@ def run(config_file: str, nd: int, test: bool = False) -> Tuple[Dict, Dict, floa
         get_client()
         use_dask = True
     except ValueError:
+        logging.getLogger("foqus." + __name__).exception(
+            "Unable to load Dask client, continuing without it using original algorithms"
+        )
         pass
 
     if sf_method == "nusf":

--- a/foqus_lib/framework/sdoe/test/nusf_benchmark.py
+++ b/foqus_lib/framework/sdoe/test/nusf_benchmark.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+#################################################################################
+# FOQUS Copyright (c) 2012 - 2023, by the software owners: Oak Ridge Institute
+# for Science and Education (ORISE), TRIAD National Security, LLC., Lawrence
+# Livermore National Security, LLC., The Regents of the University of
+# California, through Lawrence Berkeley National Laboratory, Battelle Memorial
+# Institute, Pacific Northwest Division through Pacific Northwest National
+# Laboratory, Carnegie Mellon University, West Virginia University, Boston
+# University, the Trustees of Princeton University, The University of Texas at
+# Austin, URS Energy & Construction, Inc., et al.  All rights reserved.
+#
+# Please see the file LICENSE.md for full copyright and license information,
+# respectively. This file is also available online at the URL
+# "https://github.com/CCSI-Toolset/FOQUS".
+#################################################################################
+import time
+
+import numpy as np
+import pandas as pd
+from dask.distributed import Client
+
+from foqus_lib.framework.sdoe import df_utils, nusf, nusf_dask
+
+
+def main():
+    client = Client()
+
+    ## NUSF set up
+    index = "__id"
+    inputs = ["L", "G", "w", "lldg"]
+    weight = "CI Width Prior"
+    nr = 10
+    nd = 10
+    mode = "maximin"
+    hist = None
+    scale_method = "direct_mwr"  # "ranked_mwr"
+    mwr_values = [5, 10, 20, 40, 60]
+
+    cand = df_utils.load(fname="candidates_nusf.csv", index=index)
+
+    rand_seed = 23112209280756322351382740501499295435
+
+    MAX = 4
+    iteration_sample_sizes = [10**x for x in range(1, MAX)]
+    random_starts_sample_sizes = [10 * x for x in range(1, MAX)]
+    df = pd.DataFrame(
+        {
+            "Random Starts": random_starts_sample_sizes * len(iteration_sample_sizes),
+            "Max Iterations": [
+                element
+                for element in iteration_sample_sizes
+                for _ in range(len(random_starts_sample_sizes))
+            ],
+            "Original Time": [None]
+            * len(iteration_sample_sizes)
+            * len(random_starts_sample_sizes),
+            "Using Dask Time": [None]
+            * len(iteration_sample_sizes)
+            * len(random_starts_sample_sizes),
+        }
+    )
+    print(f"iteration sample sizes: {iteration_sample_sizes}")
+    print(f"random starts sample sizes: {random_starts_sample_sizes}")
+
+    for i in random_starts_sample_sizes:
+        for j in iteration_sample_sizes:
+            args = {
+                "icol": index,
+                "xcols": inputs,
+                "wcol": weight,
+                "max_iterations": j,
+                "mwr_values": mwr_values,
+                "scale_method": scale_method,
+            }
+            t0 = time.time()
+            results = nusf.criterion(
+                cand, args, i, nd, mode=mode, hist=hist, rand_seed=rand_seed
+            )
+            df.loc[
+                (df["Random Starts"] == i) & (df["Max Iterations"] == j),
+                "Original Time",
+            ] = (
+                time.time() - t0
+            )
+            # was occasionally having issues with Dask shutting down but referencing the client here stopped that
+            print(client)
+            t0 = time.time()
+            dask_results = nusf_dask.criterion(
+                cand, args, i, nd, mode=mode, hist=hist, rand_seed=rand_seed
+            )
+            df.loc[
+                (df["Random Starts"] == i) & (df["Max Iterations"] == j),
+                "Using Dask Time",
+            ] = (
+                time.time() - t0
+            )
+            print(
+                f"Random start num = {i}\n{df.loc[(df['Random Starts'] == i) & (df['Max Iterations'] == j)]}"
+            )
+            for mwr in mwr_values:
+                assert results[mwr]["best_cand"].equals(dask_results[mwr]["best_cand"])
+                assert results[mwr]["best_cand_scaled"].equals(
+                    dask_results[mwr]["best_cand_scaled"]
+                )
+                assert results[mwr]["best_val"] == dask_results[mwr]["best_val"]
+                assert results[mwr]["best_mties"] == dask_results[mwr]["best_mties"]
+
+    df.to_csv("nusf_test_times.csv", index=False)
+    print(df)
+
+
+if __name__ == "__main__":
+    main()

--- a/foqus_lib/framework/sdoe/test/test_nusf_dask.py
+++ b/foqus_lib/framework/sdoe/test/test_nusf_dask.py
@@ -1,0 +1,105 @@
+#################################################################################
+# FOQUS Copyright (c) 2012 - 2023, by the software owners: Oak Ridge Institute
+# for Science and Education (ORISE), TRIAD National Security, LLC., Lawrence
+# Livermore National Security, LLC., The Regents of the University of
+# California, through Lawrence Berkeley National Laboratory, Battelle Memorial
+# Institute, Pacific Northwest Division through Pacific Northwest National
+# Laboratory, Carnegie Mellon University, West Virginia University, Boston
+# University, the Trustees of Princeton University, The University of Texas at
+# Austin, URS Energy & Construction, Inc., et al.  All rights reserved.
+#
+# Please see the file LICENSE.md for full copyright and license information,
+# respectively. This file is also available online at the URL
+# "https://github.com/CCSI-Toolset/FOQUS".
+#################################################################################
+import numpy as np
+import pandas as pd
+
+from foqus_lib.framework.sdoe import df_utils, nusf, nusf_dask
+
+
+def test_criterion():
+
+    cand = pd.DataFrame([(1, 1, 1), (2, 2, 1), (3, 3, 1), (4, 4, 1)])
+    args = {
+        "icol": "",
+        "xcols": [0, 1],
+        "scale_factors": pd.Series(1.0, index=range(len(cand))),
+        "wcol": 2,
+        "max_iterations": 100,
+        "mwr_values": [1, 2, 4, 8, 16],
+        "scale_method": "direct_mwr",
+    }
+    nr = 3
+    nd = 2
+    mode = "maximin"
+    hist = None
+
+    result = nusf_dask.criterion(
+        cand=cand, args=args, nr=nr, nd=nd, mode=mode, hist=hist
+    )
+
+    for mwr in args["mwr_values"]:
+        assert result[mwr].get("best_cand") is not None
+
+
+def test_same_results_as_nusf():
+    index = "__id"
+    inputs = ["L", "G", "w", "lldg"]
+    weight = "CI Width Prior"
+    nr = 5
+    nd = 10
+    mode = "maximin"
+    hist = None
+    scale_method = "direct_mwr"
+    mwr_values = [5, 10, 20, 40, 60]
+
+    cand = df_utils.load(fname="candidates_nusf.csv", index=index)
+    args = {
+        "icol": index,
+        "xcols": inputs,
+        "wcol": weight,
+        "max_iterations": 5,
+        "mwr_values": mwr_values,
+        "scale_method": scale_method,
+    }
+
+    rand_seed = 23112209280756322351382740501499295435
+
+    results = nusf.criterion(
+        cand, args, nr, nd, mode=mode, hist=hist, rand_seed=rand_seed
+    )
+    dask_results = nusf_dask.criterion(
+        cand, args, nr, nd, mode=mode, hist=hist, rand_seed=rand_seed
+    )
+    for mwr in mwr_values:
+        assert results[mwr]["best_cand"].equals(dask_results[mwr]["best_cand"])
+        assert results[mwr]["best_cand_scaled"].equals(
+            dask_results[mwr]["best_cand_scaled"]
+        )
+        assert results[mwr]["best_val"] == dask_results[mwr]["best_val"]
+        assert results[mwr]["best_mties"] == dask_results[mwr]["best_mties"]
+
+    scale_method = "ranked_mwr"
+    args = {
+        "icol": index,
+        "xcols": inputs,
+        "wcol": weight,
+        "max_iterations": 5,
+        "mwr_values": mwr_values,
+        "scale_method": scale_method,
+    }
+
+    results = nusf.criterion(
+        cand, args, nr, nd, mode=mode, hist=hist, rand_seed=rand_seed
+    )
+    dask_results = nusf_dask.criterion(
+        cand, args, nr, nd, mode=mode, hist=hist, rand_seed=rand_seed
+    )
+    for mwr in mwr_values:
+        assert results[mwr]["best_cand"].equals(dask_results[mwr]["best_cand"])
+        assert results[mwr]["best_cand_scaled"].equals(
+            dask_results[mwr]["best_cand_scaled"]
+        )
+        assert results[mwr]["best_val"] == dask_results[mwr]["best_val"]
+        assert results[mwr]["best_mties"] == dask_results[mwr]["best_mties"]

--- a/foqus_lib/framework/sdoe/test/test_nusf_dask.py
+++ b/foqus_lib/framework/sdoe/test/test_nusf_dask.py
@@ -12,13 +12,16 @@
 # respectively. This file is also available online at the URL
 # "https://github.com/CCSI-Toolset/FOQUS".
 #################################################################################
-import numpy as np
+import os
+
+import dask.config as dconf
 import pandas as pd
 
 from foqus_lib.framework.sdoe import df_utils, nusf, nusf_dask
 
 
 def test_criterion():
+    dconf.set({"dataframe.convert-string": False})
 
     cand = pd.DataFrame([(1, 1, 1), (2, 2, 1), (3, 3, 1), (4, 4, 1)])
     args = {
@@ -44,6 +47,8 @@ def test_criterion():
 
 
 def test_same_results_as_nusf():
+    dconf.set({"dataframe.convert-string": False})
+
     index = "__id"
     inputs = ["L", "G", "w", "lldg"]
     weight = "CI Width Prior"
@@ -54,7 +59,9 @@ def test_same_results_as_nusf():
     scale_method = "direct_mwr"
     mwr_values = [5, 10, 20, 40, 60]
 
-    cand = df_utils.load(fname="candidates_nusf.csv", index=index)
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    csv_file_path = os.path.join(dir_path, "candidates_nusf.csv")
+    cand = df_utils.load(fname=csv_file_path, index=index)
     args = {
         "icol": index,
         "xcols": inputs,

--- a/foqus_lib/framework/sdoe/test/test_usf_dask.py
+++ b/foqus_lib/framework/sdoe/test/test_usf_dask.py
@@ -67,3 +67,12 @@ def test_same_result_as_usf():
         cand, args, nr, nd, mode=mode, hist=hist, rand_gen=rand_gen_dask
     )
     assert results["best_cand"].equals(dask_results["best_cand"])
+
+    mode = "minimax"
+    rand_gen = np.random.default_rng(23112209280756322351382740501499295435)
+    rand_gen_dask = np.random.default_rng(23112209280756322351382740501499295435)
+    results = usf.criterion(cand, args, nr, nd, mode=mode, hist=hist, rand_gen=rand_gen)
+    dask_results = usf_dask.criterion(
+        cand, args, nr, nd, mode=mode, hist=hist, rand_gen=rand_gen_dask
+    )
+    assert results["best_cand"].equals(dask_results["best_cand"])

--- a/foqus_lib/framework/sdoe/test/test_usf_dask.py
+++ b/foqus_lib/framework/sdoe/test/test_usf_dask.py
@@ -12,6 +12,7 @@
 # respectively. This file is also available online at the URL
 # "https://github.com/CCSI-Toolset/FOQUS".
 #################################################################################
+import dask.config as dconf
 import numpy as np
 import pandas as pd
 
@@ -19,6 +20,7 @@ from foqus_lib.framework.sdoe import df_utils, usf, usf_dask
 
 
 def test_criterion():
+    dconf.set({"dataframe.convert-string": False})
 
     cand = pd.DataFrame([(1, 1), (2, 2), (3, 3), (4, 4)])
     args = {
@@ -39,6 +41,7 @@ def test_criterion():
 
 
 def test_same_result_as_usf():
+    dconf.set({"dataframe.convert-string": False})
     index = "__id"
     inputs = ["w", "G", "lldg", "L"]
     min_vals = [0.0, 0.12, 1000.0, 0.1, 3020.0]

--- a/foqus_lib/framework/sdoe/test/test_usf_dask.py
+++ b/foqus_lib/framework/sdoe/test/test_usf_dask.py
@@ -17,7 +17,7 @@ from unittest import result
 import numpy as np
 import pandas as pd
 
-from foqus_lib.framework.sdoe import df_utils, usf, usf_dask, usf_scalesci
+from foqus_lib.framework.sdoe import df_utils, usf, usf_dask
 
 
 def test_criterion():

--- a/foqus_lib/framework/sdoe/test/test_usf_dask.py
+++ b/foqus_lib/framework/sdoe/test/test_usf_dask.py
@@ -1,0 +1,69 @@
+#################################################################################
+# FOQUS Copyright (c) 2012 - 2023, by the software owners: Oak Ridge Institute
+# for Science and Education (ORISE), TRIAD National Security, LLC., Lawrence
+# Livermore National Security, LLC., The Regents of the University of
+# California, through Lawrence Berkeley National Laboratory, Battelle Memorial
+# Institute, Pacific Northwest Division through Pacific Northwest National
+# Laboratory, Carnegie Mellon University, West Virginia University, Boston
+# University, the Trustees of Princeton University, The University of Texas at
+# Austin, URS Energy & Construction, Inc., et al.  All rights reserved.
+#
+# Please see the file LICENSE.md for full copyright and license information,
+# respectively. This file is also available online at the URL
+# "https://github.com/CCSI-Toolset/FOQUS".
+#################################################################################
+from unittest import result
+
+import numpy as np
+import pandas as pd
+
+from foqus_lib.framework.sdoe import df_utils, usf, usf_dask, usf_scalesci
+
+
+def test_criterion():
+
+    cand = pd.DataFrame([(1, 1), (2, 2), (3, 3), (4, 4)])
+    args = {
+        "icol": "",
+        "xcols": [0, 1],
+        "scale_factors": pd.Series(1.0, index=range(len(cand))),
+    }
+    nr = 3
+    nd = 2
+    mode = "maximin"
+    hist = None
+
+    result = usf_dask.criterion(
+        cand=cand, args=args, nr=nr, nd=nd, mode=mode, hist=hist
+    )
+
+    assert result.get("best_cand") is not None
+
+
+def test_same_result_as_usf():
+    index = "__id"
+    inputs = ["w", "G", "lldg", "L"]
+    min_vals = [0.0, 0.12, 1000.0, 0.1, 3020.0]
+    max_vals = [241.0, 0.18, 2700.0, 0.3, 11392.0]
+    nr = 1000
+    nd = 2
+    mode = "maximin"
+    hist = None
+
+    include = inputs.copy()
+    include.append(index)
+    scl = np.array([ub - lb for ub, lb in zip(max_vals, min_vals)])
+    cand = df_utils.load(fname="candidates_usf.csv", index=index)
+    args = {
+        "icol": index,
+        "xcols": inputs,
+        "scale_factors": pd.Series(scl, index=include),
+    }
+    rand_gen = np.random.default_rng(23112209280756322351382740501499295435)
+    rand_gen_dask = np.random.default_rng(23112209280756322351382740501499295435)
+
+    results = usf.criterion(cand, args, nr, nd, mode=mode, hist=hist, rand_gen=rand_gen)
+    dask_results = usf_dask.criterion(
+        cand, args, nr, nd, mode=mode, hist=hist, rand_gen=rand_gen_dask
+    )
+    assert results["best_cand"].equals(dask_results["best_cand"])

--- a/foqus_lib/framework/sdoe/test/test_usf_dask.py
+++ b/foqus_lib/framework/sdoe/test/test_usf_dask.py
@@ -12,8 +12,6 @@
 # respectively. This file is also available online at the URL
 # "https://github.com/CCSI-Toolset/FOQUS".
 #################################################################################
-from unittest import result
-
 import numpy as np
 import pandas as pd
 
@@ -59,8 +57,10 @@ def test_same_result_as_usf():
         "xcols": inputs,
         "scale_factors": pd.Series(scl, index=include),
     }
-    rand_gen = np.random.default_rng(23112209280756322351382740501499295435)
-    rand_gen_dask = np.random.default_rng(23112209280756322351382740501499295435)
+    rand_seed = 23112209280756322351382740501499295435
+
+    rand_gen = np.random.default_rng(rand_seed)
+    rand_gen_dask = np.random.default_rng(rand_seed)
 
     results = usf.criterion(cand, args, nr, nd, mode=mode, hist=hist, rand_gen=rand_gen)
     dask_results = usf_dask.criterion(
@@ -69,8 +69,8 @@ def test_same_result_as_usf():
     assert results["best_cand"].equals(dask_results["best_cand"])
 
     mode = "minimax"
-    rand_gen = np.random.default_rng(23112209280756322351382740501499295435)
-    rand_gen_dask = np.random.default_rng(23112209280756322351382740501499295435)
+    rand_gen = np.random.default_rng(rand_seed)
+    rand_gen_dask = np.random.default_rng(rand_seed)
     results = usf.criterion(cand, args, nr, nd, mode=mode, hist=hist, rand_gen=rand_gen)
     dask_results = usf_dask.criterion(
         cand, args, nr, nd, mode=mode, hist=hist, rand_gen=rand_gen_dask

--- a/foqus_lib/framework/sdoe/test/test_usf_dask.py
+++ b/foqus_lib/framework/sdoe/test/test_usf_dask.py
@@ -12,6 +12,8 @@
 # respectively. This file is also available online at the URL
 # "https://github.com/CCSI-Toolset/FOQUS".
 #################################################################################
+import os
+
 import dask.config as dconf
 import numpy as np
 import pandas as pd
@@ -51,10 +53,12 @@ def test_same_result_as_usf():
     mode = "maximin"
     hist = None
 
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    csv_file_path = os.path.join(dir_path, "candidates_usf.csv")
+    cand = df_utils.load(fname=csv_file_path, index=index)
     include = inputs.copy()
     include.append(index)
     scl = np.array([ub - lb for ub, lb in zip(max_vals, min_vals)])
-    cand = df_utils.load(fname="candidates_usf.csv", index=index)
     args = {
         "icol": index,
         "xcols": inputs,

--- a/foqus_lib/framework/sdoe/test/usf_benchmark.py
+++ b/foqus_lib/framework/sdoe/test/usf_benchmark.py
@@ -43,8 +43,9 @@ def main():
         "xcols": inputs,
         "scale_factors": pd.Series(scl, index=include),
     }
-    rand_gen = np.random.default_rng(23112209280756322351382740501499295435)
-    rand_gen_dask = np.random.default_rng(23112209280756322351382740501499295435)
+    rand_seed = 23112209280756322351382740501499295435
+    rand_gen = np.random.default_rng(rand_seed)
+    rand_gen_dask = np.random.default_rng(rand_seed)
 
     # run across range of 10^1 to 10^6 for both types
     sample_sizes = [10**x for x in range(1, 7)]
@@ -68,7 +69,7 @@ def main():
         dask_results = usf_dask.criterion(
             cand, args, i, nd, mode=mode, hist=hist, rand_gen=rand_gen_dask
         )
-        # assert results["best_cand"].equals(dask_results["best_cand"])
+        assert results["best_cand"].equals(dask_results["best_cand"])
         df.loc[df["Random Starts"] == i, "Using Dask Time"] = time.time() - t0
         print(f"Random start num = {i}\n{df.loc[df['Random Starts'] == i]}")
 

--- a/foqus_lib/framework/sdoe/test/usf_benchmark.py
+++ b/foqus_lib/framework/sdoe/test/usf_benchmark.py
@@ -13,9 +13,10 @@
 # respectively. This file is also available online at the URL
 # "https://github.com/CCSI-Toolset/FOQUS".
 #################################################################################
+import time
+
 import numpy as np
 import pandas as pd
-import time
 from dask.distributed import Client
 
 from foqus_lib.framework.sdoe import df_utils, usf, usf_dask

--- a/foqus_lib/framework/sdoe/test/usf_benchmark.py
+++ b/foqus_lib/framework/sdoe/test/usf_benchmark.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+#################################################################################
+# FOQUS Copyright (c) 2012 - 2023, by the software owners: Oak Ridge Institute
+# for Science and Education (ORISE), TRIAD National Security, LLC., Lawrence
+# Livermore National Security, LLC., The Regents of the University of
+# California, through Lawrence Berkeley National Laboratory, Battelle Memorial
+# Institute, Pacific Northwest Division through Pacific Northwest National
+# Laboratory, Carnegie Mellon University, West Virginia University, Boston
+# University, the Trustees of Princeton University, The University of Texas at
+# Austin, URS Energy & Construction, Inc., et al.  All rights reserved.
+#
+# Please see the file LICENSE.md for full copyright and license information,
+# respectively. This file is also available online at the URL
+# "https://github.com/CCSI-Toolset/FOQUS".
+#################################################################################
+import numpy as np
+import pandas as pd
+from dask.distributed import Client
+
+from foqus_lib.framework.sdoe import df_utils, usf, usf_dask
+
+
+def main():
+    client = Client()
+
+    ## USF set up
+    index = "__id"
+    inputs = ["w", "G", "lldg", "L"]
+    min_vals = [0.0, 0.12, 1000.0, 0.1, 3020.0]
+    max_vals = [241.0, 0.18, 2700.0, 0.3, 11392.0]
+    nd = 2
+    mode = "maximin"
+    hist = None
+
+    include = inputs.copy()
+    include.append(index)
+    scl = np.array([ub - lb for ub, lb in zip(max_vals, min_vals)])
+    cand = df_utils.load(fname="candidates_usf.csv", index=index)
+    args = {
+        "icol": index,
+        "xcols": inputs,
+        "scale_factors": pd.Series(scl, index=include),
+    }
+    rand_gen = np.random.default_rng(23112209280756322351382740501499295435)
+    rand_gen_dask = np.random.default_rng(23112209280756322351382740501499295435)
+
+    # run across range of 10^1 to 10^6 for both types
+    sample_sizes = [10**x for x in range(1, 7)]
+    df = pd.DataFrame(
+        {
+            "Random Starts": sample_sizes,
+            "Original Time": [None] * len(sample_sizes),
+            "Using Dask Time": [None] * len(sample_sizes),
+        }
+    )
+    print(f"sample sizes: {sample_sizes}")
+
+    for i in sample_sizes:
+        results = usf.criterion(
+            cand, args, i, nd, mode=mode, hist=hist, rand_gen=rand_gen
+        )
+        dask_results = usf_dask.criterion(
+            cand, args, i, nd, mode=mode, hist=hist, rand_gen=rand_gen_dask
+        )
+        # assert results["best_cand"].equals(dask_results["best_cand"])
+        df.loc[df["Random Starts"] == i, "Original Time"] = results["elapsed_time"]
+        df.loc[df["Random Starts"] == i, "Using Dask Time"] = dask_results[
+            "elapsed_time"
+        ]
+        print(f"Random start num = {i}\n{df.loc[df['Random Starts'] == i]}")
+
+    df.to_csv("test_times.csv", index=False)
+    print(df)
+
+
+if __name__ == "__main__":
+    main()

--- a/foqus_lib/framework/sdoe/test/usf_benchmark.py
+++ b/foqus_lib/framework/sdoe/test/usf_benchmark.py
@@ -15,6 +15,7 @@
 #################################################################################
 import numpy as np
 import pandas as pd
+import time
 from dask.distributed import Client
 
 from foqus_lib.framework.sdoe import df_utils, usf, usf_dask
@@ -56,20 +57,21 @@ def main():
     print(f"sample sizes: {sample_sizes}")
 
     for i in sample_sizes:
+        t0 = time.time()
         results = usf.criterion(
             cand, args, i, nd, mode=mode, hist=hist, rand_gen=rand_gen
         )
+        df.loc[df["Random Starts"] == i, "Original Time"] = time.time() - t0
+        print(client)
+        t0 = time.time()
         dask_results = usf_dask.criterion(
             cand, args, i, nd, mode=mode, hist=hist, rand_gen=rand_gen_dask
         )
         # assert results["best_cand"].equals(dask_results["best_cand"])
-        df.loc[df["Random Starts"] == i, "Original Time"] = results["elapsed_time"]
-        df.loc[df["Random Starts"] == i, "Using Dask Time"] = dask_results[
-            "elapsed_time"
-        ]
+        df.loc[df["Random Starts"] == i, "Using Dask Time"] = time.time() - t0
         print(f"Random start num = {i}\n{df.loc[df['Random Starts'] == i]}")
 
-    df.to_csv("test_times.csv", index=False)
+    df.to_csv("usf_test_times.csv", index=False)
     print(df)
 
 

--- a/foqus_lib/framework/sdoe/test/usf_benchmark.py
+++ b/foqus_lib/framework/sdoe/test/usf_benchmark.py
@@ -15,6 +15,7 @@
 #################################################################################
 import time
 
+import dask.config as dconf
 import numpy as np
 import pandas as pd
 from dask.distributed import Client
@@ -23,6 +24,8 @@ from foqus_lib.framework.sdoe import df_utils, usf, usf_dask
 
 
 def main():
+    dconf.set({"dataframe.convert-string": False})
+
     client = Client()
 
     ## USF set up

--- a/foqus_lib/framework/sdoe/usf.py
+++ b/foqus_lib/framework/sdoe/usf.py
@@ -42,7 +42,7 @@ def criterion(
     nd: int,
     mode: str = "maximin",
     hist: Optional[pd.DataFrame] = None,
-    rand_gen=np.random.default_rng(),
+    rand_gen: np.random.Generator = np.random.default_rng(),
 ) -> TypedDict(
     "results",
     {

--- a/foqus_lib/framework/sdoe/usf_dask.py
+++ b/foqus_lib/framework/sdoe/usf_dask.py
@@ -16,14 +16,9 @@ import time
 from operator import gt, lt
 
 import numpy as np
+import dask.bag as db
 
-from .distance import compute_dist
-
-
-def compute_min_dist(mat, scl, hist_xs=None):
-    dmat = compute_dist(mat, scl=scl, hist_xs=hist_xs)
-    min_dist = np.min(dmat, axis=0)
-    return dmat, min_dist
+from .usf import compute_min_dist
 
 
 def criterion(
@@ -48,7 +43,6 @@ def criterion(
         cond = lt
 
     # indices of type ...
-    _id_ = args["icol"]  # Index
     idx = args["xcols"]  # Input
 
     # scaling factors
@@ -61,33 +55,28 @@ def criterion(
     else:
         hist_xs = None
 
-    best_cand = []
-    _best_rand_sample = []
-
     t0 = time.time()
-    for i in range(nr):
-        # sample without replacement <nd> indices
-        rand_index = rand_gen.choice(cand.index, nd, replace=False)
-        # extract the <nd> rows
-        rand_cand = cand.loc[rand_index]
-        # extract the relevant columns (of type 'Input' only) for dist computations
-        dmat, min_dist = compute_min_dist(rand_cand[idx].values, scl, hist_xs=hist_xs)
-        dist = fcn(min_dist)
+    choices = []
+    for i in range(nr):  # create all the choices upfront
+        choices.append(rand_gen.choice(cand.index, nd, replace=False))
+    nrs = db.from_sequence(choices, npartitions=(nr // 1000) + 1)
+    part_choices = nrs.map_partitions(
+        choose_from_partition, best_val, cand, idx, scl, hist_xs, fcn, cond
+    ).to_dataframe()
+    if mode == "maximin":
+        best_val = part_choices["val"].max()
+    else:
+        best_val = part_choices["val"].min()
 
-        if cond(dist, best_val):
-            best_cand = rand_cand
-            best_index = rand_index  # for debugging
-            best_val = dist  # for debugging
-            best_dmat = dmat  # used for ranking candidates
+    best = part_choices[part_choices.val == best_val].compute()
 
-        elapsed_time = time.time() - t0
-    # best_cand.insert(loc=0, column=id_, value=best_cand.index)
+    elapsed_time = time.time() - t0
 
     results = {
-        "best_cand": best_cand,
-        "best_index": best_index,
-        "best_val": best_val,
-        "best_dmat": best_dmat,
+        "best_cand": best["cand"].iloc[0],
+        "best_index": best["index"].iloc[0],
+        "best_val": best["val"].iloc[0],
+        "best_dmat": best["dmat"].iloc[0],
         "dmat_cols": idx,
         "mode": mode,
         "design_size": nd,
@@ -96,3 +85,25 @@ def criterion(
     }
 
     return results
+
+
+def choose_from_partition(nums, starting_val, cand, idx, scl, hist_xs, fcn, cond):
+    best_cand, best_val = None, starting_val
+    for i in nums:
+        rand_cand = choose(i, cand, idx, scl, hist_xs, fcn)
+        if cond(rand_cand["val"], best_val):
+            best_cand = rand_cand
+    return [best_cand]
+
+
+def choose(choice, cand, idx, scl, hist_xs, fcn):
+    rand_cand = cand.loc[choice]
+    # extract the relevant columns (of type 'Input' only) for dist computations
+    dmat, min_dist = compute_min_dist(rand_cand[idx].values, scl, hist_xs=hist_xs)
+    dist = fcn(min_dist)
+    return {
+        "cand": rand_cand,
+        "index": choice,
+        "val": dist,
+        "dmat": dmat,
+    }

--- a/foqus_lib/framework/sdoe/usf_dask.py
+++ b/foqus_lib/framework/sdoe/usf_dask.py
@@ -93,6 +93,7 @@ def choose_from_partition(nums, starting_val, cand, idx, scl, hist_xs, fcn, cond
         rand_cand = choose(i, cand, idx, scl, hist_xs, fcn)
         if cond(rand_cand["val"], best_val):
             best_cand = rand_cand
+            best_val = rand_cand["val"]
     return [best_cand]
 
 

--- a/foqus_lib/gui/sdoe/sdoeAnalysisDialog.py
+++ b/foqus_lib/gui/sdoe/sdoeAnalysisDialog.py
@@ -41,6 +41,8 @@ _sdoeAnalysisDialogUI, _sdoeAnalysisDialog = uic.loadUiType(
 )
 
 USF_SAMPLES = 4000
+
+
 class sdoeAnalysisDialog(_sdoeAnalysisDialog, _sdoeAnalysisDialogUI):
 
     # Info table

--- a/foqus_lib/gui/sdoe/sdoeAnalysisDialog.py
+++ b/foqus_lib/gui/sdoe/sdoeAnalysisDialog.py
@@ -40,7 +40,7 @@ _sdoeAnalysisDialogUI, _sdoeAnalysisDialog = uic.loadUiType(
     os.path.join(mypath, "sdoeAnalysisDialog_UI.ui")
 )
 
-
+USF_SAMPLES = 4000
 class sdoeAnalysisDialog(_sdoeAnalysisDialog, _sdoeAnalysisDialogUI):
 
     # Info table
@@ -625,7 +625,7 @@ class sdoeAnalysisDialog(_sdoeAnalysisDialog, _sdoeAnalysisDialogUI):
 
         if test:
             if self.type == "USF":
-                f.write("number_random_starts = 200\n")
+                f.write("number_random_starts = %d\n" % USF_SAMPLES)
             else:
                 f.write("number_random_starts = 2\n")
         else:
@@ -1217,7 +1217,8 @@ class sdoeAnalysisDialog(_sdoeAnalysisDialog, _sdoeAnalysisDialogUI):
         return reply
 
     def updateRunTime(self, runtime):
-        delta = runtime / 200
+        print(f"reported runtime={runtime}")
+        delta = (runtime) / USF_SAMPLES
         estimateTime = int(
             delta
             * (10 ** int(self.sampleSize_spin.value()))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ pylint==2.14.1
 # since there can be significant differences between (non-major) versions,
 # both in terms of behavior and performance
 astroid==2.11.6
-pytest
+pytest<8.1
 ### coverage
 coverage
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ dist = setup(
         "bokeh!=3.0.*,>=2.4.2",
         "boto3",
         "cma",
-        "dask[distributed]",
+        "dask[dataframe,distributed]<2024.3",
         "matplotlib<3.6",
         "python-tsp==0.3.1",
         "joblib<1.3",  # CCSI-Toolset/FOQUS#1154

--- a/setup.py
+++ b/setup.py
@@ -89,8 +89,10 @@ dist = setup(
     # Required packages needed in the users env go here (non-versioned strongly preferred).
     # requirements.txt should stay empty (other than the "-e .")
     install_requires=[
+        "bokeh!=3.0.*,>=2.4.2",
         "boto3",
         "cma",
+        "dask[distributed]",
         "matplotlib<3.6",
         "python-tsp==0.3.1",
         "joblib<1.3",  # CCSI-Toolset/FOQUS#1154

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ dist = setup(
         "bokeh!=3.0.*,>=2.4.2",
         "boto3",
         "cma",
-        "dask[dataframe,distributed]<2024.3",
+        "dask[dataframe,distributed]",  # <2024.3",
         "matplotlib<3.6",
         "python-tsp==0.3.1",
         "joblib<1.3",  # CCSI-Toolset/FOQUS#1154


### PR DESCRIPTION
## Fixes/Addresses:

#1193 

## Summary/Motivation:

In order to improve the performance of the USF and NUSF algorithms for SDoE we parallelize them utilizing Dask. 

We verify that the parallelized implementation provides the same result as the original algorithm with performance gain (USF 2.5x across platforms; NUSF 3.5x on Windows).

## Changes proposed in this PR:
- parallelized USF and NUSF algorithms utilizing Dask
- FOQUS command line option to utilize Dask for SDoE algorithms
- update to using Generator for random numbers generation for USF and NUSF (from legacy RandomState generators)
- tests to verify that the parallelized implementation provides the same results as the original algorithm given the same random number sequence
- benchmark to measure performance of the parallelized implementation vs the original algorithm

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
