### PR TITLE
Add Turbine Configuration Section To Debugging Documentation

### DIFF
--- a/docs/source/chapt_debug/index.rst
+++ b/docs/source/chapt_debug/index.rst
@@ -78,7 +78,7 @@ behavior that users can modify to suit their needs. The "User Settings"
 section of the file passes timeout values which cap how many minutes
 Turbine will let a certain action occur before force-stopping.
 
-On a local machine, the file is located at "C:\Program Files (x86)\Turbine\Lite\Clients\AspenSinterConsumerConsole.exe.config" and
+On a local machine, the file is located at :file:`C:\Program Files (x86)\Turbine\Lite\Clients\AspenSinterConsumerConsole.exe.config` and
 requires administrative access to save edits. FOQUS and Aspen need to
 be closed when you save the file so Turbine can update its config for
 new instances. Lines 93-108 set the "User Settings", which include the

--- a/docs/source/chapt_debug/index.rst
+++ b/docs/source/chapt_debug/index.rst
@@ -68,4 +68,21 @@ The following are known unresolved issues:
    TurbineLite port is changed the configuration file that FOQUS uses to
    connect to TurbineLite, must also be changed.
 
+Turbine Configuration
+---------------------
+
+Turbine Lite uses a configuration file to set many runtime options for
+submitted jobs, most of which are pre-set server information based on the
+software version. However, there are a few options which control the run
+behavior that users can modify to suit their needs. The "User Settings"
+section of the file passes timeout values which cap how many minutes
+Turbine will let a certain action occur before force-stopping.
+
+On a local machine, the file is located at "C:\Program Files (x86)\Turbine\Lite\Clients\AspenSinterConsumerConsole.exe.config" and
+requires administrative access to save edits. FOQUS and Aspen need to
+be closed when you save the file so Turbine can update its config for
+new instances. Lines 93-108 set the "User Settings", which include the
+timeout for the total run, the timeout for the run setup, and the timeout
+for the post initialization run. These values are all in minutes.
+
 .. include:: ../contact.rst

--- a/docs/source/chapt_debug/index.rst
+++ b/docs/source/chapt_debug/index.rst
@@ -78,7 +78,7 @@ behavior that users can modify to suit their needs. The "User Settings"
 section of the file passes timeout values which cap how many minutes
 Turbine will let a certain action occur before force-stopping.
 
-On a local machine, the file is located at "C:\\Program Files (x86)\\Turbine\\Lite\\Clients\\AspenSinterConsumerConsole.exe.config" and
+On a local machine, the file is located at :file:`C:\\Program Files (x86)\\Turbine\\Lite\\Clients\\AspenSinterConsumerConsole.exe.config` and
 requires administrative access to save edits. FOQUS and Aspen need to
 be closed when you save the file so Turbine can update its config for
 new instances. Lines 93-108 set the "User Settings", which include the

--- a/docs/source/chapt_debug/index.rst
+++ b/docs/source/chapt_debug/index.rst
@@ -78,7 +78,7 @@ behavior that users can modify to suit their needs. The "User Settings"
 section of the file passes timeout values which cap how many minutes
 Turbine will let a certain action occur before force-stopping.
 
-On a local machine, the file is located at :file:`C:/Program Files (x86)/Turbine/Lite/Clients/AspenSinterConsumerConsole.exe.config` and
+On a local machine, the file is located at :file:`C:\\Program Files (x86)\\Turbine\\Lite\\Clients\\AspenSinterConsumerConsole.exe.config` and
 requires administrative access to save edits. FOQUS and Aspen need to
 be closed when you save the file so Turbine can update its config for
 new instances. Lines 93-108 set the "User Settings", which include the

--- a/docs/source/chapt_debug/index.rst
+++ b/docs/source/chapt_debug/index.rst
@@ -78,7 +78,7 @@ behavior that users can modify to suit their needs. The "User Settings"
 section of the file passes timeout values which cap how many minutes
 Turbine will let a certain action occur before force-stopping.
 
-On a local machine, the file is located at :file:`C:\Program Files (x86)\Turbine\Lite\Clients\AspenSinterConsumerConsole.exe.config` and
+On a local machine, the file is located at :file:`C:/Program Files (x86)/Turbine/Lite/Clients/AspenSinterConsumerConsole.exe.config` and
 requires administrative access to save edits. FOQUS and Aspen need to
 be closed when you save the file so Turbine can update its config for
 new instances. Lines 93-108 set the "User Settings", which include the

--- a/docs/source/chapt_debug/index.rst
+++ b/docs/source/chapt_debug/index.rst
@@ -78,7 +78,7 @@ behavior that users can modify to suit their needs. The "User Settings"
 section of the file passes timeout values which cap how many minutes
 Turbine will let a certain action occur before force-stopping.
 
-On a local machine, the file is located at :file:`C:\\Program Files (x86)\\Turbine\\Lite\\Clients\\AspenSinterConsumerConsole.exe.config` and
+On a local machine, the file is located at "C:\\Program Files (x86)\\Turbine\\Lite\\Clients\\AspenSinterConsumerConsole.exe.config" and
 requires administrative access to save edits. FOQUS and Aspen need to
 be closed when you save the file so Turbine can update its config for
 new instances. Lines 93-108 set the "User Settings", which include the


### PR DESCRIPTION
## Fixes/Addresses:

Adds information on Turbine Configuration file to debugging section of the FOQUS documentation.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
