### PR TITLE
update FOQUS documentation to include info on how to set paths for SimSinter and TurbineLite

### DIFF
--- a/docs/source/chapt_install/install_optional.rst
+++ b/docs/source/chapt_install/install_optional.rst
@@ -51,6 +51,17 @@ Install Turbine and SimSinter (Windows Only)
     4. right-click "Turbine Web API Service" from the list, and
     5. click "Start"
 
+* Configure the location of the executables in FOQUS
+
+  * SimSinter
+
+    1. In "Settings" (see Figure 1 below) go to the "FOQUS" tab
+    2. Modify the "SimSinter Home" field to point to the directory you installed SimSinter
+
+  * TurbineLite
+
+    1. In "Settings" (see Figure 1 below) go to the "Turbine" tab
+    2. In the "TurbineLite (local)" section modify the "TurbineLite Home" field to point to the directory you installed TurbineLite
 
 Install ALAMO
 ^^^^^^^^^^^^^


### PR DESCRIPTION
update FOQUS documentation to include info on how to set paths for SimSinter and TurbineLite

## Fixes/Addresses:

#1190 

## Summary/Motivation:

With version 3 of SimSinter and TurbineLite the applications were upgraded to 64-bit and thus their default installation paths changed. FOQUS default paths for these point to the 32-bit Windows default installation paths. 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
