### PR TITLE
A few more copyright year updates

### DIFF
--- a/.addheader.yml
+++ b/.addheader.yml
@@ -1,5 +1,5 @@
 # Usage:
-# addheader -c addheader.yml
+# addheader -c .addheader.yml -P ""
 root: .
 text: header_text.txt
 patterns:

--- a/.pylint/foqus_transform.py
+++ b/.pylint/foqus_transform.py
@@ -1,5 +1,5 @@
 ###############################################################################
-# FOQUS Copyright (c) 2012 - 2021, by the software owners: Oak Ridge Institute
+# FOQUS Copyright (c) 2012 - 2024, by the software owners: Oak Ridge Institute
 # for Science and Education (ORISE), TRIAD National Security, LLC., Lawrence
 # Livermore National Security, LLC., The Regents of the University of
 # California, through Lawrence Berkeley National Laboratory, Battelle Memorial
@@ -11,7 +11,6 @@
 # Please see the file LICENSE.md for full copyright and license information,
 # respectively. This file is also available online at the URL
 # "https://github.com/CCSI-Toolset/FOQUS".
-#
 ###############################################################################
 import astroid
 

--- a/.pylint/foqus_transform.py
+++ b/.pylint/foqus_transform.py
@@ -1,4 +1,4 @@
-###############################################################################
+#################################################################################
 # FOQUS Copyright (c) 2012 - 2024, by the software owners: Oak Ridge Institute
 # for Science and Education (ORISE), TRIAD National Security, LLC., Lawrence
 # Livermore National Security, LLC., The Regents of the University of
@@ -11,7 +11,7 @@
 # Please see the file LICENSE.md for full copyright and license information,
 # respectively. This file is also available online at the URL
 # "https://github.com/CCSI-Toolset/FOQUS".
-###############################################################################
+#################################################################################
 import astroid
 
 

--- a/foqus_lib/help/html/license.html
+++ b/foqus_lib/help/html/license.html
@@ -7,12 +7,12 @@
 		<H3> FOQUS License </H3>
 
 <pre>
-Copyright (c) 2012 - 2021
+Copyright (c) 2012 - 2024
 
 Copyright Notice
 
 Foqus was produced under the DOE Carbon Capture Simulation Initiative (CCSI),
-and is copyright (c) 2012 - 2021 by the software owners: Oak Ridge Institute for
+and is copyright (c) 2012 - 2024 by the software owners: Oak Ridge Institute for
 Science and Education (ORISE), TRIAD National Security, LLC., Lawrence
 Livermore National Security, LLC., The Regents of the University of California,
 through Lawrence Berkeley National Laboratory, Battelle Memorial Institute,
@@ -30,7 +30,7 @@ perform publicly and display publicly, and to permit other to do so.
 
 License Agreement
 
-Foqus Copyright (c) 2012 - 2021, by the software owners: Oak Ridge Institute for
+Foqus Copyright (c) 2012 - 2024, by the software owners: Oak Ridge Institute for
 Science and Education (ORISE), TRIAD National Security, LLC., Lawrence
 Livermore National Security, LLC., The Regents of the University of California,
 through Lawrence Berkeley National Laboratory, Battelle Memorial Institute,

--- a/foqus_lib/version/version.template
+++ b/foqus_lib/version/version.template
@@ -8,7 +8,7 @@ import argparse, sys
 version = "{VERSION}"
 copyright =  \
 """Foqus was produced under the DOE Carbon Capture Simulation Initiative (CCSI),
-and is copyright (c) 2012 - 2021 by the software owners: Oak Ridge Institute for
+and is copyright (c) 2012 - 2024 by the software owners: Oak Ridge Institute for
 Science and Education (ORISE), TRIAD National Security, LLC., Lawrence Livermore
 National Security, LLC., The Regents of the University of California, through
 Lawrence Berkeley National Laboratory, Battelle Memorial Institute, Pacific


### PR DESCRIPTION
## Fixes/Addresses:

Found a couple more files with the old copyright dates.  Also fixed usage example in `.addheader.yml` file

## Summary/Motivation:

The copyright years in the help dialogs were still "2012 - 2021"

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
