### PR TITLE
Fixes for bugs related to SDOE in 3.21-rc

### DIFF
--- a/foqus_lib/gui/sdoe/sdoeAnalysisDialog.py
+++ b/foqus_lib/gui/sdoe/sdoeAnalysisDialog.py
@@ -849,7 +849,7 @@ class sdoeAnalysisDialog(_sdoeAnalysisDialog, _sdoeAnalysisDialogUI):
                 "mwr = %d, n = %d" % (mwr, results[mwr]["num_restarts"])
             )
             count += 1
-            self.SDOE2_progressBar.setValue((100 / len(mwr_list)) * count)
+            self.SDOE2_progressBar.setValue(int((100 / len(mwr_list)) * count))
             QApplication.processEvents()
 
         self.unfreeze()

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,8 @@ dist = setup(
         "cma",
         "dask[dataframe,distributed]",  # <2024.3",
         # prebuilt wheels not available on 3.11 for matplotlib<3.6 on: macos arm64, win32
-        "matplotlib==3.*",
+        # matplotlib>=3.8 has API incompatibilities with SDoE plots
+        "matplotlib >= 3.6.0, <= 3.7.5",
         "python-tsp==0.3.1",
         "mplcursors",
         "numpy",

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ dist = setup(
         "dask[dataframe,distributed]",  # <2024.3",
         # prebuilt wheels not available on 3.11 for matplotlib<3.6 on: macos arm64, win32
         # matplotlib>=3.8 has API incompatibilities with SDoE plots
+        # see CCSI-Toolset/FOQUS#1211 for more information
         "matplotlib >= 3.6.0, <= 3.7.5",
         "python-tsp==0.3.1",
         "mplcursors",


### PR DESCRIPTION
## Fixes/Addresses:

- result plots of SDOE runs would fail to display in some cases, e.g. NUSF
- #1209 

## Summary/Motivation:

Fix bugs that are present in RC as related to SDOE UX

## Changes proposed in this PR:
- pin matplotlib between 3.6.0 and 3.7.5 (<3.6 doesn't have wheels for python 3.11 and 3.8 introduces the issue with the plotting of results)
- fix setValue that was missed previously

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
