### PR TITLE
Removing xfail for TestOUU.testRunOUU

### DIFF
--- a/foqus_lib/gui/tests/test_ouu.py
+++ b/foqus_lib/gui/tests/test_ouu.py
@@ -282,10 +282,6 @@ class TestOUU:
         n_vars = len(self.frame.input_table.getUQDiscreteVariables()[0])
         assert n_inps == n_vars
 
-    @pytest.mark.xfail(
-        reason="This test is known to fail intermittently on macOS. See CCSI-Toolset/FOQUS#1195",
-        strict=False,
-    )
     def testRunOUU(self, runUntilConfirmationDialog):
         """
         [Test-5] Test that the optimizer launches and finishes.


### PR DESCRIPTION
## Fixes/Addresses:

Addresses #1195 by removing xfail since I was not able to get it to fail.

## Summary/Motivation:

Can't reproduce this failure on my fancy new MacOS laptop with an M3 Max CPU.

## Changes proposed in this PR:
- Remove the `pytest.mark.xfail` for `TestOUU.testRunOUU`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
