### PR TITLE
Update Codecov CI configuration

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -128,9 +128,37 @@ jobs:
           name: pytest-dir-${{ matrix.os }}-py${{ matrix.python-version }}
           path: ${{ env.PYTEST_BASETEMP }}
           retention-days: 7
+    - name: Upload coverage report as job artifact
+      if: always() && matrix.use_coverage
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report-${{ matrix.os }}
+        path: coverage.xml
+        if-no-files-found: error
+
+  upload-coverage:
+    name: Upload coverage report (Codecov)
+    needs: [pytest]
+    runs-on: ubuntu-latest
+    steps:
+      # the checkout step is needed to have access to codecov.yml
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-report-*
       - name: Upload coverage report to Codecov
-        if: matrix.use_coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: true
+          verbose: true
+          # NOTE: secrets are not available for pull_request workflows
+          # However, as of 2024-02-10, Codecov is still allowing tokenless upload from PRs
+          # but does require token for other workflows e.g. merge to `main`
+          # see https://github.com/codecov/codecov-action/issues/1274#issuecomment-1934437359
+          token: ${{ secrets.CODECOV_TOKEN }}
+          # pinning version after v0.7.0 broke tokenless upload
+          # see codecov/codecov-action#1487
+          version: v0.7.2
 
   pylint:
     name: pylint (py${{ matrix.python-version }})

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -128,13 +128,13 @@ jobs:
           name: pytest-dir-${{ matrix.os }}-py${{ matrix.python-version }}
           path: ${{ env.PYTEST_BASETEMP }}
           retention-days: 7
-    - name: Upload coverage report as job artifact
-      if: always() && matrix.use_coverage
-      uses: actions/upload-artifact@v4
-      with:
-        name: coverage-report-${{ matrix.os }}
-        path: coverage.xml
-        if-no-files-found: error
+      - name: Upload coverage report as job artifact
+        if: always() && matrix.use_coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report-${{ matrix.os }}
+          path: coverage.xml
+          if-no-files-found: error
 
   upload-coverage:
     name: Upload coverage report (Codecov)


### PR DESCRIPTION
## Fixes/Addresses:

Codecov upload failures

## Changes proposed in this PR:
- Use dedicated dependent job for Codecov upload (so that, in case of failure, only that job needs to be restarted, as opposed to the test suite that generated the coverage report)
- Update Action to `codecov/codecov-action@v4`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
