### PR TITLE
Fix "Log" Scaling

### DIFF
--- a/foqus_lib/framework/graph/nodeVars.py
+++ b/foqus_lib/framework/graph/nodeVars.py
@@ -725,7 +725,7 @@ class NodeVars(object):
             elif self.scaling == "Linear":
                 out = val * (self.max - self.min) / 10.0 + self.min
             elif self.scaling == "Log":
-                out = math.pow(self.min * (self.max / self.min), (val / 10.0))
+                out = self.min * math.pow((self.max / self.min), (val / 10.0))
             elif self.scaling == "Power":
                 out = math.log10(
                     (val / 10.0) * (math.pow(10, self.max) - math.pow(10, self.min))

--- a/foqus_lib/unit_test/nodeVars_test.py
+++ b/foqus_lib/unit_test/nodeVars_test.py
@@ -100,12 +100,12 @@ class testNodeVarsSteady(unittest.TestCase):
 
     def testScaleLog(self):
         var = self.makeVar()
-        var.min = 1
+        var.min = 2
         var.max = 25
         var.value = 4.12
         var.scaling = "Log"
         var.scale()
-        self.assertAlmostEqual(var.scaled, 4.3986, places=3)
+        self.assertAlmostEqual(var.scaled, 2.8614, places=3)
 
     def testScalePower(self):
         var = self.makeVar()
@@ -145,9 +145,9 @@ class testNodeVarsSteady(unittest.TestCase):
 
     def testUnScaleLog(self):
         var = self.makeVar()
-        var.min = 1
+        var.min = 2
         var.max = 25
-        var.scaled = 4.3986
+        var.scaled = 2.8614
         var.scaling = "Log"
         var.unscale()
         self.assertAlmostEqual(var.value, 4.12, places=3)

--- a/foqus_lib/unit_test/nodeVars_test.py
+++ b/foqus_lib/unit_test/nodeVars_test.py
@@ -91,12 +91,12 @@ class testNodeVarsSteady(unittest.TestCase):
 
     def testScaleLinear(self):
         var = self.makeVar()
-        var.min = 1
+        var.min = 2
         var.max = 25
         var.value = 4.12
         var.scaling = "Linear"
         var.scale()
-        self.assertAlmostEqual(var.scaled, 1.3)
+        self.assertAlmostEqual(var.scaled, 0.9217, places=3)
 
     def testScaleLog(self):
         var = self.makeVar()
@@ -109,39 +109,39 @@ class testNodeVarsSteady(unittest.TestCase):
 
     def testScalePower(self):
         var = self.makeVar()
-        var.min = 0
+        var.min = 0.1
         var.max = 2
         var.value = 0.2
         var.scaling = "Power"
         var.scale()
-        self.assertAlmostEqual(var.scaled, 0.0591, places=3)
+        self.assertAlmostEqual(var.scaled, 0.0330, places=3)
 
     def testScaleLog2(self):
         var = self.makeVar()
-        var.min = 1
+        var.min = 2
         var.max = 25
         var.value = 4.12
         var.scaling = "Log 2"
         var.scale()
-        self.assertAlmostEqual(var.scaled, 3.3646, places=3)
+        self.assertAlmostEqual(var.scaled, 2.6235, places=3)
 
     def testScalePower2(self):
         var = self.makeVar()
-        var.min = 1
+        var.min = 2
         var.max = 25
         var.value = 4.12
         var.scaling = "Power 2"
         var.scale()
-        self.assertAlmostEqual(var.scaled, 0.3877, places=3)
+        self.assertAlmostEqual(var.scaled, 0.2627, places=3)
 
     def testUnScaleLinear(self):
         var = self.makeVar()
-        var.min = 1
+        var.min = 2
         var.max = 25
-        var.scaled = 1.3
+        var.scaled = 0.9217
         var.scaling = "Linear"
         var.unscale()
-        self.assertAlmostEqual(var.value, 4.12)
+        self.assertAlmostEqual(var.value, 4.12, places=3)
 
     def testUnScaleLog(self):
         var = self.makeVar()
@@ -154,27 +154,27 @@ class testNodeVarsSteady(unittest.TestCase):
 
     def testUnScalePower(self):
         var = self.makeVar()
-        var.min = 0
+        var.min = 0.1
         var.max = 2
-        var.scaled = 0.059080120451
+        var.scaled = 0.0330
         var.scaling = "Power"
         var.unscale()
         self.assertAlmostEqual(var.value, 0.2, places=3)
 
     def testUnScaleLog2(self):
         var = self.makeVar()
-        var.min = 1
+        var.min = 2
         var.max = 25
-        var.scaled = 3.3646
+        var.scaled = 2.6235
         var.scaling = "Log 2"
         var.unscale()
         self.assertAlmostEqual(var.value, 4.12, places=3)
 
     def testUnScalePower2(self):
         var = self.makeVar()
-        var.min = 1
+        var.min = 2
         var.max = 25
-        var.scaled = 0.3877365362129
+        var.scaled = 0.2627
         var.scaling = "Power 2"
         var.unscale()
         self.assertAlmostEqual(var.value, 4.12, places=3)


### PR DESCRIPTION
## Fixes/Addresses: #1233 

## Summary/Motivation:

Corrects unscaling formula for "Log" scaling formulation.

## Changes proposed in this PR:
- Fix "Log" unscaling formula
- Updates tests to avoid false successes due to `self.min` having a value of 1 or 0

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
