### PR TITLE
Adding Aspen Consumer Configuration Panel

### DIFF
--- a/foqus_lib/framework/surrogate/ACOSSO.py
+++ b/foqus_lib/framework/surrogate/ACOSSO.py
@@ -18,7 +18,7 @@ Surrogate plugins need to have the string "#FOQUS_SURROGATE_PLUGIN" near the
 beginning of the file (see pluginSearch.plugins() for exact character count of
 text).  They also need to have a .py extension and inherit the surrogate class.
 
-* Plugin wprapper for the ACOSSO surrogate model builer.
+* Plugin wrapper for the ACOSSO surrogate model builder.
 * ACOSSO is executed in R and a working R install with the quadprog
   package is required.  The user must install R
 * ACOSSO Ref:

--- a/foqus_lib/framework/surrogate/BSS-ANOVA.py
+++ b/foqus_lib/framework/surrogate/BSS-ANOVA.py
@@ -18,7 +18,7 @@ Surrogate plugins need to have the string "#FOQUS_SURROGATE_PLUGIN" near the
 beginning of the file (see pluginSearch.plugins() for exact character count of
 text).  They also need to have a .py extension and inherit the surrogate class.
 
-* Plugin wrapper for the BSS-ANOVA surrogate model builer.
+* Plugin wrapper for the BSS-ANOVA surrogate model builder.
 * BSS-ANOVA is executed in R and a working R install with the quadprog
   package is required.  The user must install R
 * BSS-ANOVA Ref:

--- a/foqus_lib/gui/flowsheet/nodePanel.py
+++ b/foqus_lib/gui/flowsheet/nodePanel.py
@@ -942,3 +942,14 @@ class nodeDock(_nodeDock, _nodeDockUI):
         # Write the modified content back to the file
         with open(self.configFile_edit.text(), "w", encoding="utf-8") as file:
             file.write(content)
+
+        msgBox = QMessageBox()
+        msgBox.setWindowTitle("Aspen Consumer Configuration File")
+        dirname = os.path.dirname(self.configFile_edit.text())
+        msgBox.setText(
+            "The Aspen Consumer configuration file has been successfully updated.\n"
+            "\nPlease make sure your changes are correct before loading it into Aspen.\n"
+            "\nA backup of the old version has been saved in the directory below:\n"
+            "\n" + dirname
+        )
+        msgBox.exec_()

--- a/foqus_lib/gui/flowsheet/nodePanel.py
+++ b/foqus_lib/gui/flowsheet/nodePanel.py
@@ -19,14 +19,24 @@ John Eslick, Carnegie Mellon University, 2014
 """
 import ast
 import os
+import re
 import platform
 import types
 from configparser import RawConfigParser
 from io import StringIO
+from shutil import copyfile
+import time
 
 from PyQt5 import QtCore, uic
 from PyQt5.QtGui import QColor
-from PyQt5.QtWidgets import QAbstractItemView, QInputDialog, QLineEdit, QMessageBox
+from PyQt5.QtWidgets import (
+    QAbstractItemView,
+    QInputDialog,
+    QLineEdit,
+    QMessageBox,
+    QFileDialog,
+    QTableWidgetItem,
+)
 
 import foqus_lib.gui.helpers.guiHelpers as gh
 from foqus_lib.framework.graph.node import *
@@ -42,6 +52,10 @@ class nodeDock(_nodeDock, _nodeDockUI):
     redrawFlowsheet = QtCore.pyqtSignal()  # request flowsheet redraw
     waiting = QtCore.pyqtSignal()  # indicates a task is going take a while
     notwaiting = QtCore.pyqtSignal()  # indicates a wait is over
+
+    parameterCol = 0
+    valueCol = 1
+    descriptionCol = 2
 
     def __init__(self, dat, parent=None):
         """
@@ -80,6 +94,13 @@ class nodeDock(_nodeDock, _nodeDockUI):
         self.nodeNameBox.setEditable(False)
         self.synhi = PythonHighlighter(self.pyCode.document())
         self.sim_mapping = None
+        self.configFileBrowse_button.clicked.connect(self.loadConfigFile)
+        self.config_file = None
+        self.starts = None
+        self.ends = None
+        self.updateConfigTable()
+        self.updateConfig_button.setEnabled(False)
+        self.updateConfig_button.clicked.connect(self.updateConfigFile)
 
     def changeNode(self, index):
         newNode = self.nodeNameBox.currentText()
@@ -787,3 +808,120 @@ class nodeDock(_nodeDock, _nodeDockUI):
         self.applyChanges()
         event.accept()
         self.mw.toggleNodeEditorAction.setChecked(False)
+
+    def loadConfigFile(self):
+
+        # Get file name
+        if platform.system() == "Windows":
+            _allFiles = "*.*"
+        else:
+            _allFiles = "*"
+        fileName, selectedFilter = QFileDialog.getOpenFileName(
+            self,
+            "Open Configuration File",
+            "",
+            "Extensible Markup Language (XML) (*.xml)",
+        )
+        if len(fileName) == 0:
+            return
+
+        if fileName.endswith(".xml"):
+            try:
+                with open(fileName, "r", encoding="utf-8") as file:
+                    self.config_file = file.read()
+                self.configFile_edit.setText(fileName)
+                self.updateConfigTable()
+            except Exception as e:
+                QMessageBox.critical(
+                    self,
+                    "File Error",
+                    f"Error: {e}",
+                )
+
+        else:
+            QMessageBox.critical(
+                self,
+                "Incorrect file extension",
+                "Please make sure an XML file with Aspen Consumer Configuration "
+                "information has been selected.",
+            )
+
+    def updateConfigTable(self):
+        if self.config_file is not None:
+            timeout_text = '<setting name="TimeOutIterations" serializeAs="String">'
+            setup_text = '<setting name="TimeOutSetupIterations" serializeAs="String">'
+            init_text = '<setting name="TimePostInitIterations" serializeAs="String">'
+            text_dict = {
+                "timeout": timeout_text,
+                "setup": setup_text,
+                "init": init_text,
+            }
+        else:
+            return
+
+        def get_config_vals(text_dictionary):
+            vals = {"timeout": None, "setup": None, "init": None}
+            starts = {"timeout": None, "setup": None, "init": None}
+            ends = {"timeout": None, "setup": None, "init": None}
+            for key, text in text_dictionary.items():
+                pattern = re.compile(rf"{re.escape(text)}\s*<value>(.*?)</value>")
+                matches = pattern.finditer(self.config_file)
+
+                for match in matches:
+                    start_index = match.start(1)
+                    end_index = match.end(1)
+                    current_val = self.config_file[start_index:end_index]
+                starts[key] = start_index
+                ends[key] = end_index
+                vals[key] = current_val
+
+            return vals, starts, ends
+
+        current_vals, current_starts, current_ends = get_config_vals(text_dict)
+
+        self.starts = current_starts
+        self.ends = current_ends
+
+        # Update table rows
+        for row, key in enumerate(current_vals):
+            self.updateConfigTableRow(row, current_vals[key])
+
+        self.updateConfig_button.setEnabled(True)
+
+    def updateConfigTableRow(self, row, text):
+        item = self.configTable.item(row, self.valueCol)
+        if item is None:
+            item = QTableWidgetItem()
+        item.setText(text)
+        item.setTextAlignment(QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
+        flags = item.flags()
+        mask = QtCore.Qt.ItemIsEnabled
+        item.setFlags(flags | mask)
+        self.configTable.setItem(row, self.valueCol, item)
+
+    def updateConfigFile(self):
+        # Backup current XML file
+        config_file, ext = os.path.splitext(self.configFile_edit.text())
+        backup_file = config_file + "-backup-" + str(time.time()) + ext
+        copyfile(self.configFile_edit.text(), backup_file)
+
+        # Get values from table
+        new_vals = {
+            "timeout": self.configTable.item(0, 1).text(),
+            "setup": self.configTable.item(1, 1).text(),
+            "init": self.configTable.item(2, 1).text(),
+        }
+
+        # Perform the replacement
+        content = self.config_file
+        for key in new_vals:
+            # Insert new_text at start_index
+            content = (
+                content[: self.starts[key]]
+                + str(new_vals[key])
+                + content[self.starts[key] + len(str(new_vals[key])) :]
+            )
+
+        # Write the modified content back to the file
+        with open(self.configFile_edit.text(), "w", encoding="utf-8") as file:
+            file.write(content)

--- a/foqus_lib/gui/flowsheet/nodePanel_UI.ui
+++ b/foqus_lib/gui/flowsheet/nodePanel_UI.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1138</width>
-    <height>758</height>
+    <width>1440</width>
+    <height>847</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -381,7 +381,7 @@
                  <string>DMF Server</string>
                 </property>
                </item>
-			   <item>
+               <item>
                 <property name="text">
                  <string>ML_AI</string>
                 </property>
@@ -441,15 +441,15 @@
         <item>
          <widget class="QToolBox" name="toolBox">
           <property name="currentIndex">
-           <number>1</number>
+           <number>3</number>
           </property>
           <widget class="QWidget" name="page">
            <property name="geometry">
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>1096</width>
-             <height>385</height>
+             <width>365</width>
+             <height>296</height>
             </rect>
            </property>
            <attribute name="label">
@@ -749,8 +749,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>1096</width>
-             <height>385</height>
+             <width>260</width>
+             <height>147</height>
             </rect>
            </property>
            <attribute name="label">
@@ -924,8 +924,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>98</width>
-             <height>89</height>
+             <width>103</width>
+             <height>103</height>
             </rect>
            </property>
            <attribute name="label">
@@ -950,6 +950,82 @@
                </property>
               </column>
              </widget>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="page_4">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>1370</width>
+             <height>339</height>
+            </rect>
+           </property>
+           <attribute name="label">
+            <string>Aspen Configuration Parameters</string>
+           </attribute>
+           <layout class="QVBoxLayout" name="verticalLayout_13">
+            <item>
+             <layout class="QVBoxLayout" name="verticalLayout_12">
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_6">
+                <item>
+                 <widget class="QLabel" name="configFile_static">
+                  <property name="text">
+                   <string>Configuration File</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLineEdit" name="configFile_edit">
+                  <property name="text">
+                   <string>\Program Files (x86)\Turbine\Lite\Consumers\AspenSinterConsumerConsole.xml</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="configFileBrowse_button">
+                  <property name="text">
+                   <string>Browse...</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_6">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <widget class="QTableWidget" name="configTable">
+                <column>
+                 <property name="text">
+                  <string>Parameter</string>
+                 </property>
+                </column>
+                <column>
+                 <property name="text">
+                  <string>Value</string>
+                 </property>
+                </column>
+                <column>
+                 <property name="text">
+                  <string>Description</string>
+                 </property>
+                </column>
+               </widget>
+              </item>
+             </layout>
             </item>
            </layout>
           </widget>

--- a/foqus_lib/gui/flowsheet/nodePanel_UI.ui
+++ b/foqus_lib/gui/flowsheet/nodePanel_UI.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1440</width>
-    <height>847</height>
+    <width>3440</width>
+    <height>1387</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -448,8 +448,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>365</width>
-             <height>296</height>
+             <width>3370</width>
+             <height>879</height>
             </rect>
            </property>
            <attribute name="label">
@@ -749,8 +749,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>260</width>
-             <height>147</height>
+             <width>3370</width>
+             <height>879</height>
             </rect>
            </property>
            <attribute name="label">
@@ -924,8 +924,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>103</width>
-             <height>103</height>
+             <width>3370</width>
+             <height>879</height>
             </rect>
            </property>
            <attribute name="label">
@@ -958,72 +958,179 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>1370</width>
-             <height>339</height>
+             <width>3370</width>
+             <height>879</height>
             </rect>
            </property>
            <attribute name="label">
             <string>Aspen Configuration Parameters</string>
            </attribute>
-           <layout class="QVBoxLayout" name="verticalLayout_13">
+           <layout class="QVBoxLayout" name="verticalLayout_12">
             <item>
-             <layout class="QVBoxLayout" name="verticalLayout_12">
+             <layout class="QHBoxLayout" name="horizontalLayout_6">
               <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_6">
-                <item>
-                 <widget class="QLabel" name="configFile_static">
-                  <property name="text">
-                   <string>Configuration File</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLineEdit" name="configFile_edit">
-                  <property name="text">
-                   <string>\Program Files (x86)\Turbine\Lite\Consumers\AspenSinterConsumerConsole.xml</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QPushButton" name="configFileBrowse_button">
-                  <property name="text">
-                   <string>Browse...</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <spacer name="horizontalSpacer_6">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>40</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-               </layout>
+               <widget class="QLabel" name="configFile_static">
+                <property name="text">
+                 <string>Configuration File</string>
+                </property>
+               </widget>
               </item>
               <item>
-               <widget class="QTableWidget" name="configTable">
-                <column>
-                 <property name="text">
-                  <string>Parameter</string>
-                 </property>
-                </column>
-                <column>
-                 <property name="text">
-                  <string>Value</string>
-                 </property>
-                </column>
-                <column>
-                 <property name="text">
-                  <string>Description</string>
-                 </property>
-                </column>
+               <widget class="QLineEdit" name="configFile_edit">
+                <property name="text">
+                 <string>\Program Files (x86)\Turbine\Lite\Consumers\AspenSinterConsumerConsole.xml</string>
+                </property>
                </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="configFileBrowse_button">
+                <property name="text">
+                 <string>Browse...</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_6">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QTableWidget" name="configTable">
+              <row>
+               <property name="text">
+                <string/>
+               </property>
+              </row>
+              <row>
+               <property name="text">
+                <string/>
+               </property>
+              </row>
+              <row>
+               <property name="text">
+                <string/>
+               </property>
+              </row>
+              <column>
+               <property name="text">
+                <string>Parameter</string>
+               </property>
+              </column>
+              <column>
+               <property name="text">
+                <string>Value</string>
+               </property>
+              </column>
+              <column>
+               <property name="text">
+                <string>Description</string>
+               </property>
+              </column>
+              <item row="0" column="0">
+               <property name="text">
+                <string>TimeOutIterations</string>
+               </property>
+               <property name="flags">
+                <set>ItemIsDragEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
+               </property>
+              </item>
+              <item row="0" column="1">
+               <property name="text">
+                <string/>
+               </property>
+               <property name="flags">
+                <set>ItemIsSelectable|ItemIsEditable|ItemIsDragEnabled|ItemIsUserCheckable</set>
+               </property>
+              </item>
+              <item row="0" column="2">
+               <property name="text">
+                <string/>
+               </property>
+               <property name="flags">
+                <set>ItemIsDragEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
+               </property>
+              </item>
+              <item row="1" column="0">
+               <property name="text">
+                <string>TimeOutSetupIterations</string>
+               </property>
+               <property name="flags">
+                <set>ItemIsDragEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
+               </property>
+              </item>
+              <item row="1" column="1">
+               <property name="text">
+                <string/>
+               </property>
+               <property name="flags">
+                <set>ItemIsSelectable|ItemIsEditable|ItemIsDragEnabled|ItemIsUserCheckable</set>
+               </property>
+              </item>
+              <item row="1" column="2">
+               <property name="text">
+                <string/>
+               </property>
+               <property name="flags">
+                <set>ItemIsDragEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
+               </property>
+              </item>
+              <item row="2" column="0">
+               <property name="text">
+                <string>TimePostInitIterations</string>
+               </property>
+               <property name="flags">
+                <set>ItemIsDragEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
+               </property>
+              </item>
+              <item row="2" column="1">
+               <property name="text">
+                <string/>
+               </property>
+               <property name="flags">
+                <set>ItemIsSelectable|ItemIsEditable|ItemIsDragEnabled|ItemIsUserCheckable</set>
+               </property>
+              </item>
+              <item row="2" column="2">
+               <property name="text">
+                <string/>
+               </property>
+               <property name="flags">
+                <set>ItemIsDragEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_7">
+              <item>
+               <widget class="QPushButton" name="updateConfig_button">
+                <property name="text">
+                 <string>Update Configuration Parameters</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_10">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
               </item>
              </layout>
             </item>

--- a/foqus_lib/gui/flowsheet/nodePanel_UI.ui
+++ b/foqus_lib/gui/flowsheet/nodePanel_UI.ui
@@ -441,7 +441,7 @@
         <item>
          <widget class="QToolBox" name="toolBox">
           <property name="currentIndex">
-           <number>3</number>
+           <number>0</number>
           </property>
           <widget class="QWidget" name="page">
            <property name="geometry">
@@ -925,7 +925,7 @@
              <x>0</x>
              <y>0</y>
              <width>3370</width>
-             <height>367</height>
+             <height>879</height>
             </rect>
            </property>
            <attribute name="label">

--- a/foqus_lib/gui/flowsheet/nodePanel_UI.ui
+++ b/foqus_lib/gui/flowsheet/nodePanel_UI.ui
@@ -449,7 +449,7 @@
              <x>0</x>
              <y>0</y>
              <width>3370</width>
-             <height>879</height>
+             <height>367</height>
             </rect>
            </property>
            <attribute name="label">
@@ -750,7 +750,7 @@
              <x>0</x>
              <y>0</y>
              <width>3370</width>
-             <height>879</height>
+             <height>367</height>
             </rect>
            </property>
            <attribute name="label">
@@ -925,7 +925,7 @@
              <x>0</x>
              <y>0</y>
              <width>3370</width>
-             <height>879</height>
+             <height>367</height>
             </rect>
            </property>
            <attribute name="label">
@@ -959,7 +959,7 @@
              <x>0</x>
              <y>0</y>
              <width>3370</width>
-             <height>879</height>
+             <height>367</height>
             </rect>
            </property>
            <attribute name="label">
@@ -1004,28 +1004,23 @@
               </item>
              </layout>
             </item>
-            <item>
+            <item alignment="Qt::AlignTop">
              <widget class="QTableWidget" name="configTable">
               <row>
                <property name="text">
-                <string/>
+                <string>TimeOutIterations</string>
                </property>
               </row>
               <row>
                <property name="text">
-                <string/>
+                <string>TimeOutSetupIterations</string>
                </property>
               </row>
               <row>
                <property name="text">
-                <string/>
+                <string>TimePostInitIterations</string>
                </property>
               </row>
-              <column>
-               <property name="text">
-                <string>Parameter</string>
-               </property>
-              </column>
               <column>
                <property name="text">
                 <string>Value</string>
@@ -1038,21 +1033,13 @@
               </column>
               <item row="0" column="0">
                <property name="text">
-                <string>TimeOutIterations</string>
-               </property>
-               <property name="flags">
-                <set>ItemIsDragEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
-               </property>
-              </item>
-              <item row="0" column="1">
-               <property name="text">
                 <string/>
                </property>
                <property name="flags">
                 <set>ItemIsSelectable|ItemIsEditable|ItemIsDragEnabled|ItemIsUserCheckable</set>
                </property>
               </item>
-              <item row="0" column="2">
+              <item row="0" column="1">
                <property name="text">
                 <string/>
                </property>
@@ -1062,21 +1049,13 @@
               </item>
               <item row="1" column="0">
                <property name="text">
-                <string>TimeOutSetupIterations</string>
-               </property>
-               <property name="flags">
-                <set>ItemIsDragEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
-               </property>
-              </item>
-              <item row="1" column="1">
-               <property name="text">
                 <string/>
                </property>
                <property name="flags">
                 <set>ItemIsSelectable|ItemIsEditable|ItemIsDragEnabled|ItemIsUserCheckable</set>
                </property>
               </item>
-              <item row="1" column="2">
+              <item row="1" column="1">
                <property name="text">
                 <string/>
                </property>
@@ -1086,21 +1065,13 @@
               </item>
               <item row="2" column="0">
                <property name="text">
-                <string>TimePostInitIterations</string>
-               </property>
-               <property name="flags">
-                <set>ItemIsDragEnabled|ItemIsUserCheckable|ItemIsEnabled</set>
-               </property>
-              </item>
-              <item row="2" column="1">
-               <property name="text">
                 <string/>
                </property>
                <property name="flags">
                 <set>ItemIsSelectable|ItemIsEditable|ItemIsDragEnabled|ItemIsUserCheckable</set>
                </property>
               </item>
-              <item row="2" column="2">
+              <item row="2" column="1">
                <property name="text">
                 <string/>
                </property>
@@ -1137,6 +1108,19 @@
            </layout>
           </widget>
          </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
         </item>
        </layout>
       </widget>


### PR DESCRIPTION
## Fixes/Addresses:

It addresses issue #1199

## Summary/Motivation:
Sometimes the user might want to modify the timeout parameters in Aspen. Instead of making the user to go and modify an XML file, this panel helps them just type in a number and FOQUS will update the configuration file with the click of a button.

## Changes proposed in this PR:
- added  tab to the node panel with a table that gets populated with the current values in the configuration file.
- added logic so the user can modify the values and the file gets updated correctly

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
