### PR TITLE
Spelling and RTD build fixes for latest update of typos and sphinx_rtd_theme

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -168,7 +168,6 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []
 # html_theme_path = ['_themes', ]
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.
 # "<project> v<release> documentation" by default.

--- a/examples/test_files/Smoke_Tests/fs_smoke_test.py
+++ b/examples/test_files/Smoke_Tests/fs_smoke_test.py
@@ -164,7 +164,7 @@ def add_UQ_yes(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def uq_sampling_scheme_MC(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme with Monte Carlo, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme with Monte Carlo, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     global errorTitle
     errorTitle = "Monte Carlo"
@@ -188,7 +188,7 @@ def uq_sampling_scheme_MC(MainWin=MainWin, getButton=getButton, timers=timers, g
 
 
 def uq_sampling_scheme_QMC(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme with Quasi Monte Carlo, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme with Quasi Monte Carlo, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     global errorTitle
     errorTitle = "Quasi Monte Carlo/Lognormal Dist"
@@ -214,7 +214,7 @@ def uq_sampling_scheme_QMC(MainWin=MainWin, getButton=getButton, timers=timers, 
 
 
 def uq_sampling_scheme_LH(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme with Latin Hypercube, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme with Latin Hypercube, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     global errorTitle
     errorTitle = "Latin Hypercube/Triangle Distribution"
@@ -238,7 +238,7 @@ def uq_sampling_scheme_LH(MainWin=MainWin, getButton=getButton, timers=timers, g
 
 
 def uq_sampling_scheme_OA(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme with Orthogonal Array, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme with Orthogonal Array, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     global errorTitle
     errorTitle = "Orthogonal Array/Gamma Distribution"
@@ -262,7 +262,7 @@ def uq_sampling_scheme_OA(MainWin=MainWin, getButton=getButton, timers=timers, g
 
 
 def uq_sampling_scheme_MD(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme with Morris Design, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme with Morris Design, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     global errorTitle
     errorTitle = "Morris Design/Beta Distribution"
@@ -288,7 +288,7 @@ def uq_sampling_scheme_MD(MainWin=MainWin, getButton=getButton, timers=timers, g
 
 
 def uq_sampling_scheme_GMD(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme with Generalized Morris Design, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme with Generalized Morris Design, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     global errorTitle
     errorTitle = "Generalized Morris Design/Exponential Distribution"
@@ -314,7 +314,7 @@ def uq_sampling_scheme_GMD(MainWin=MainWin, getButton=getButton, timers=timers, 
 
 
 def uq_sampling_scheme_GS(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme with Gradient Sample, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme with Gradient Sample, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     global errorTitle
     errorTitle = "Gradient Sample/Weibull Distribution"
@@ -340,7 +340,7 @@ def uq_sampling_scheme_GS(MainWin=MainWin, getButton=getButton, timers=timers, g
 def uq_sampling_scheme_METIS(
     MainWin=MainWin, getButton=getButton, timers=timers, go=go
 ):
-    """Setup up an enseble sampling scheme with METIS, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme with METIS, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     global errorTitle
     errorTitle = "METIS"

--- a/examples/test_files/Smoke_Tests/optimization_smoke_test.py
+++ b/examples/test_files/Smoke_Tests/optimization_smoke_test.py
@@ -142,7 +142,7 @@ def msg_no(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def start_opt_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "optMonitor" in str(type(w)):
         timers["start_opt_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/optimization_smoke_test_BFGS.py
+++ b/examples/test_files/Smoke_Tests/optimization_smoke_test_BFGS.py
@@ -142,7 +142,7 @@ def msg_no(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def start_opt_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "optMonitor" in str(type(w)):
         timers["start_opt_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/optimization_smoke_test_COBYLA.py
+++ b/examples/test_files/Smoke_Tests/optimization_smoke_test_COBYLA.py
@@ -142,7 +142,7 @@ def msg_no(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def start_opt_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "optMonitor" in str(type(w)):
         timers["start_opt_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/optimization_smoke_test_CRS2.py
+++ b/examples/test_files/Smoke_Tests/optimization_smoke_test_CRS2.py
@@ -142,7 +142,7 @@ def msg_no(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def start_opt_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "optMonitor" in str(type(w)):
         timers["start_opt_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/optimization_smoke_test_DIRECT-L-RAND.py
+++ b/examples/test_files/Smoke_Tests/optimization_smoke_test_DIRECT-L-RAND.py
@@ -142,7 +142,7 @@ def msg_no(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def start_opt_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "optMonitor" in str(type(w)):
         timers["start_opt_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/optimization_smoke_test_DIRECT-L.py
+++ b/examples/test_files/Smoke_Tests/optimization_smoke_test_DIRECT-L.py
@@ -142,7 +142,7 @@ def msg_no(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def start_opt_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "optMonitor" in str(type(w)):
         timers["start_opt_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/optimization_smoke_test_DIRECT.py
+++ b/examples/test_files/Smoke_Tests/optimization_smoke_test_DIRECT.py
@@ -142,7 +142,7 @@ def msg_no(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def start_opt_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "optMonitor" in str(type(w)):
         timers["start_opt_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/optimization_smoke_test_ESCH.py
+++ b/examples/test_files/Smoke_Tests/optimization_smoke_test_ESCH.py
@@ -142,7 +142,7 @@ def msg_no(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def start_opt_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "optMonitor" in str(type(w)):
         timers["start_opt_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/optimization_smoke_test_ISRES.py
+++ b/examples/test_files/Smoke_Tests/optimization_smoke_test_ISRES.py
@@ -142,7 +142,7 @@ def msg_no(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def start_opt_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "optMonitor" in str(type(w)):
         timers["start_opt_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/optimization_smoke_test_NEWUOA.py
+++ b/examples/test_files/Smoke_Tests/optimization_smoke_test_NEWUOA.py
@@ -142,7 +142,7 @@ def msg_no(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def start_opt_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "optMonitor" in str(type(w)):
         timers["start_opt_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/optimization_smoke_test_Nelder-Mead.py
+++ b/examples/test_files/Smoke_Tests/optimization_smoke_test_Nelder-Mead.py
@@ -142,7 +142,7 @@ def msg_no(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def start_opt_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "optMonitor" in str(type(w)):
         timers["start_opt_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/optimization_smoke_test_OptCMA.py
+++ b/examples/test_files/Smoke_Tests/optimization_smoke_test_OptCMA.py
@@ -142,7 +142,7 @@ def msg_no(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def start_opt_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "optMonitor" in str(type(w)):
         timers["start_opt_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/optimization_smoke_test_PE.py
+++ b/examples/test_files/Smoke_Tests/optimization_smoke_test_PE.py
@@ -139,7 +139,7 @@ def msg_no(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def start_opt_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "optMonitor" in str(type(w)):
         timers["start_opt_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/optimization_smoke_test_PRAXIS.py
+++ b/examples/test_files/Smoke_Tests/optimization_smoke_test_PRAXIS.py
@@ -142,7 +142,7 @@ def msg_no(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def start_opt_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "optMonitor" in str(type(w)):
         timers["start_opt_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/optimization_smoke_test_PSUADE.py
+++ b/examples/test_files/Smoke_Tests/optimization_smoke_test_PSUADE.py
@@ -142,7 +142,7 @@ def msg_no(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def start_opt_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "optMonitor" in str(type(w)):
         timers["start_opt_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/optimization_smoke_test_SLSQP.py
+++ b/examples/test_files/Smoke_Tests/optimization_smoke_test_SLSQP.py
@@ -142,7 +142,7 @@ def msg_no(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def start_opt_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "optMonitor" in str(type(w)):
         timers["start_opt_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/optimization_smoke_test_Sbplx.py
+++ b/examples/test_files/Smoke_Tests/optimization_smoke_test_Sbplx.py
@@ -142,7 +142,7 @@ def msg_no(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def start_opt_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "optMonitor" in str(type(w)):
         timers["start_opt_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/optimization_smoke_test_constraint.py
+++ b/examples/test_files/Smoke_Tests/optimization_smoke_test_constraint.py
@@ -142,7 +142,7 @@ def msg_no(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def start_opt_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "optMonitor" in str(type(w)):
         timers["start_opt_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/smoke_test_01 - Full.py
+++ b/examples/test_files/Smoke_Tests/smoke_test_01 - Full.py
@@ -74,7 +74,7 @@ def add_UQ_okay(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def uq_sampling_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "SimSetup" in str(type(w)):
         timers["uq_sampling_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/smoke_test_01.py
+++ b/examples/test_files/Smoke_Tests/smoke_test_01.py
@@ -74,7 +74,7 @@ def add_UQ_okay(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def uq_sampling_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "SimSetup" in str(type(w)):
         timers["uq_sampling_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/uq_smoke_test_data_analysis.py
+++ b/examples/test_files/Smoke_Tests/uq_smoke_test_data_analysis.py
@@ -160,7 +160,7 @@ def add_UQ_okay(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def uq_sampling_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     global errorTitle
     errorTitle = "Set Up Sampling Scheme"

--- a/examples/test_files/Smoke_Tests/uq_smoke_test_data_visualization.py
+++ b/examples/test_files/Smoke_Tests/uq_smoke_test_data_visualization.py
@@ -158,7 +158,7 @@ def add_UQ_okay(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def uq_sampling_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     global errorTitle
     errorTitle = "Set Up Sampling Scheme"

--- a/examples/test_files/Smoke_Tests/uq_smoke_test_inference.py
+++ b/examples/test_files/Smoke_Tests/uq_smoke_test_inference.py
@@ -162,7 +162,7 @@ def add_UQ_okay(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def uq_sampling_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     global errorTitle
     errorTitle = "Set Up Sampling Scheme"

--- a/examples/test_files/Smoke_Tests/uq_smoke_test_input_importance.py
+++ b/examples/test_files/Smoke_Tests/uq_smoke_test_input_importance.py
@@ -158,7 +158,7 @@ def add_UQ_okay(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def uq_sampling_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "SimSetup" in str(type(w)):
         timers["uq_sampling_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/uq_smoke_test_polynomial.py
+++ b/examples/test_files/Smoke_Tests/uq_smoke_test_polynomial.py
@@ -74,7 +74,7 @@ def add_UQ_okay(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def uq_sampling_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "SimSetup" in str(type(w)):
         timers["uq_sampling_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/uq_smoke_test_response_surface_validation.py
+++ b/examples/test_files/Smoke_Tests/uq_smoke_test_response_surface_validation.py
@@ -158,7 +158,7 @@ def add_UQ_okay(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def uq_sampling_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     if "SimSetup" in str(type(w)):
         timers["uq_sampling_scheme"].stop()

--- a/examples/test_files/Smoke_Tests/uq_smoke_test_response_surface_visualization.py
+++ b/examples/test_files/Smoke_Tests/uq_smoke_test_response_surface_visualization.py
@@ -158,7 +158,7 @@ def add_UQ_okay(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def uq_sampling_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     global errorTitle
     errorTitle = "Setting up Sampling Scheme"

--- a/examples/test_files/Smoke_Tests/uq_smoke_test_response_uq_analysis.py
+++ b/examples/test_files/Smoke_Tests/uq_smoke_test_response_uq_analysis.py
@@ -160,7 +160,7 @@ def add_UQ_okay(MainWin=MainWin, getButton=getButton, timers=timers):
 
 
 def uq_sampling_scheme(MainWin=MainWin, getButton=getButton, timers=timers, go=go):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     w = MainWin.app.activeWindow()
     global errorTitle
     errorTitle = "Latin Hypercube"

--- a/foqus_lib/gui/main/mainWindow.py
+++ b/foqus_lib/gui/main/mainWindow.py
@@ -293,7 +293,7 @@ class mainWindow(QMainWindow):
         This function enables or disables forms that allow editing
         of the flowsheet or other session data while something is
         running in another thread.  This is to prevent
-        inconsitencies when a problem is running but the problem
+        inconsistencies when a problem is running but the problem
         or flowsheet have been changed in the meantime
         ---args---
         b: bool true to enable false to disable

--- a/test/system_test/ui_test_01.py
+++ b/test/system_test/ui_test_01.py
@@ -157,7 +157,7 @@ def add_UQ_okay(MainWin=MainWin):
 
 
 def uq_sampling_scheme(MainWin=MainWin):
-    """Setup up an enseble sampling scheme, stops timer once window comes up"""
+    """Setup up an ensemble sampling scheme, stops timer once window comes up"""
     global timers, exit_code, getButton, go
     w = MainWin.app.activeWindow()
     if "SimSetup" in str(type(w)):
@@ -268,7 +268,7 @@ try:  # Catch any exception and stop all timers before finishing up
         assert self.flowsheet.errorStat == 0
         _log.info("SUCCESS: Test03: Flowsheet run")
 
-        # 4) Start to add a UQ enseble, but cancel it.
+        # 4) Start to add a UQ ensemble, but cancel it.
         MainWin.uqSetupAction.trigger()
         if not go():
             break


### PR DESCRIPTION
## Fixes/Addresses:

Problems discovered in, but unrelated to PR #1242:

The `typos` package got smarter, so these are fixes to some newly discovered misspellings.
This also fixes a problem cause by a new release of the `sphinx_rtd_theme`.

## Summary/Motivation:

Trying to not look like the abismal spellers that we are.

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
