### PR TITLE
Draft: Updating documentation so PSUADE is not optional software

### DIFF
--- a/docs/source/chapt_install/index.rst
+++ b/docs/source/chapt_install/index.rst
@@ -23,9 +23,8 @@ FOQUS:
       conda create --name ccsi-foqus -c conda-forge python=3.10 pywin32=306
       conda activate ccsi-foqus
       pip install ccsi-foqus
+      conda install --yes -c conda-forge -c CCSI-Toolset psuade-lite=1.9  # Install psuade-lite
       foqus --make-shortcut  # Create Desktop shortcut (Windows only)
-
-  - 
   
   - In a terminal, to run::
       
@@ -44,6 +43,7 @@ Contents
 
     install_python
     install_foqus
+    install_psuade
     install_examples
     run_foqus
     install_optional

--- a/docs/source/chapt_install/install_optional.rst
+++ b/docs/source/chapt_install/install_optional.rst
@@ -10,22 +10,6 @@ Windows and is used to interface with Excel, Aspen, and gPROMS software.
 
 Other software listed below will enable additional features of FOQUS if available.
 
-Install PSUADE-Lite (current version: 1.9.0)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-PSUADE (Problem Solving environment for Uncertainty Analysis and Design Exploration) is a software
-toolkit containing a rich set of tools for performing uncertainty analysis, global sensitivity
-analysis, design optimization, model calibration, and more.
-
-`PSUADE-Lite <https://github.com/LLNL/psuade-lite>`_ is now available as a Conda package. To install just follow the steps below::
-
-  conda activate ccsi-foqus
-  conda install --yes -c conda-forge -c CCSI-Toolset psuade-lite=1.9
-  psuade --help  # quickly test that the psuade executable has been installed correctly
-
-The ``psuade`` executable should now be available within the Conda environment's folders, i.e. at the path ``$CONDA_PREFIX/bin/psuade`` (Linux, macOS) or ``%CONDA_PREFIX%\bin\psuade.exe`` (Windows).
-Once you set the full path in the corresponding field in the FOQUS GUI "Settings" tab, you should be able to use it normally within FOQUS.
-
 Install Turbine and SimSinter (Windows Only)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. note::

--- a/docs/source/chapt_install/install_psuade.rst
+++ b/docs/source/chapt_install/install_psuade.rst
@@ -1,0 +1,17 @@
+.. _install_psuade:
+
+Install PSUADE-Lite (current version: 1.9.0)
+--------------------------------------------
+
+PSUADE (Problem Solving environment for Uncertainty Analysis and Design Exploration) is a software
+toolkit containing a rich set of tools for performing uncertainty analysis, global sensitivity
+analysis, design optimization, model calibration, and more.
+
+`PSUADE-Lite <https://github.com/LLNL/psuade-lite>`_ is now available as a Conda package. To install just follow the steps below::
+
+  conda activate ccsi-foqus
+  conda install --yes -c conda-forge -c CCSI-Toolset psuade-lite=1.9
+  psuade --help  # quickly test that the psuade executable has been installed correctly
+
+The ``psuade`` executable should now be available within the Conda environment's folders, i.e. at the path ``$CONDA_PREFIX/bin/psuade`` (Linux, macOS) or ``%CONDA_PREFIX%\bin\psuade.exe`` (Windows).
+Once you set the full path in the corresponding field in the FOQUS GUI "Settings" tab, you should be able to use it normally within FOQUS.


### PR DESCRIPTION
## Fixes/Addresses:

Addresses issue #1263 

## Summary/Motivation:
Updating documentation to move psuade-lite installation instructions from optional software to required steps when installing FOQUS. This change is required since now PSUADE-Lite is a requirement for FOQUS to startup. 

## Changes proposed in this PR:
- Add psuade-lite conda install command to general FOQUS installation instructions. 
- Move psuade-lite installation instructions from Optional Software section to its own new section "Install psuade-lite"

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
