### PR TITLE
Fix nightlies to build with windows-2022

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -82,7 +82,7 @@ jobs:
           - os: linux
             os-version: ubuntu-22.04
           - os: win64
-            os-version: windows-2019
+            os-version: windows-2022
           - python-version: '3.10'  # avoid uploading coverage for full matrix
             use_coverage: true
           - python-version: '3.10'  # install ML AI dependencies with coverage run

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -40,7 +40,7 @@ jobs:
           - os: linux
             os-version: ubuntu-22.04
           - os: win64
-            os-version: windows-2019
+            os-version: windows-2022
           - foqus-install-target: stable
             pip-install-target: ccsi-foqus
           - foqus-install-target: master

--- a/foqus_lib/framework/graph/graph.py
+++ b/foqus_lib/framework/graph/graph.py
@@ -1829,7 +1829,7 @@ class Graph(threading.Thread):
            size of the problem in the branch by only looking at
            strongly connected components with that edge removed.
         4) This returns all equally good optimal tear sets.  That
-           may not really be nessicary.  For very large flowsheets
+           may not really be necessary.  For very large flowsheets
            There could be an extremely large number of optimal tear
            edge sets.
         """


### PR DESCRIPTION
## Fixes/Addresses:

Github no longer supports windows-2019 per:  https://github.com/actions/runner-images/issues/12045

## Summary/Motivation:

Get the nightlies running again

## Changes proposed in this PR:
- Change windows-2019 to windows-2022
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
