### PR TITLE
Update GHA: macos, ubuntu & conda-forge

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -95,8 +95,6 @@ jobs:
       MPLBACKEND: AGG
     steps:
       - uses: actions/checkout@v4
-      - name: Check disk usage
-        run: df -h
       - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -105,8 +103,6 @@ jobs:
           miniconda-version: latest
           channels: conda-forge
           conda-remove-defaults: true
-      - name: Check pre-installed packages
-        run: conda list
       - name: Set up FOQUS
         uses: ./.github/actions/setup-foqus
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -103,6 +103,7 @@ jobs:
           activate-environment: ${{ env.FOQUS_CONDA_ENV_NAME_DEV }}
           python-version: ${{ matrix.python-version }}
           miniconda-version: latest
+          channels: conda-forge
           conda-remove-defaults: true
       - name: Check pre-installed packages
         run: conda list

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -101,6 +101,7 @@ jobs:
           activate-environment: ${{ env.FOQUS_CONDA_ENV_NAME_DEV }}
           python-version: ${{ matrix.python-version }}
           miniconda-version: latest
+          conda-remove-defaults: true
       - name: Set up FOQUS
         uses: ./.github/actions/setup-foqus
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -97,6 +97,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check disk usage
         run: df -h
+      - name: Check pre-installed packages
+        run: conda list
       - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -80,7 +80,7 @@ jobs:
           - os: macos-arm64
             os-version: macos-14
           - os: linux
-            os-version: ubuntu-22.04
+            os-version: ubuntu-slim
           - os: win64
             os-version: windows-2022
           - python-version: '3.10'  # avoid uploading coverage for full matrix
@@ -95,11 +95,7 @@ jobs:
       MPLBACKEND: AGG
     steps:
       - uses: actions/checkout@v4
-      - name: Check disk usage before cleaning
-        run: df -h
-      - name: Clean up temporary files
-        run: sudo rm -rf /tmp/*
-      - name: Check disk usage after cleaning
+      - name: Check disk usage
         run: df -h
       - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -80,7 +80,7 @@ jobs:
           - os: macos-arm64
             os-version: macos-14
           - os: linux
-            os-version: ubuntu-slim
+            os-version: ubuntu-24.04
           - os: win64
             os-version: windows-2022
           - python-version: '3.10'  # avoid uploading coverage for full matrix
@@ -97,8 +97,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check disk usage
         run: df -h
-      - name: Check pre-installed packages
-        run: conda list
       - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -106,6 +104,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           miniconda-version: latest
           conda-remove-defaults: true
+      - name: Check pre-installed packages
+        run: conda list
       - name: Set up FOQUS
         uses: ./.github/actions/setup-foqus
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -76,7 +76,7 @@ jobs:
           - macos-arm64
         include:
           - os: macos-intel
-            os-version: macos-13
+            os-version: macos-15-intel
           - os: macos-arm64
             os-version: macos-14
           - os: linux

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -95,6 +95,12 @@ jobs:
       MPLBACKEND: AGG
     steps:
       - uses: actions/checkout@v4
+      - name: Check disk usage before cleaning
+        run: df -h
+      - name: Clean up temporary files
+        run: sudo rm -rf /tmp/*
+      - name: Check disk usage after cleaning
+        run: df -h
       - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v3
         with:

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -38,7 +38,7 @@ jobs:
           - os: macos-intel
             os-version: macos-15-intel
           - os: linux
-            os-version: ubuntu-22.04
+            os-version: ubuntu-24.04
           - os: win64
             os-version: windows-2022
           - foqus-install-target: stable
@@ -54,6 +54,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: "latest"
+          channels: conda-forge
           conda-remove-defaults: true
       - name: Install FOQUS in a Conda env (user mode)
         env:

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -36,7 +36,7 @@ jobs:
           - '3.9.0'
         include:
           - os: macos-intel
-            os-version: macos-13
+            os-version: macos-15-intel
           - os: linux
             os-version: ubuntu-22.04
           - os: win64


### PR DESCRIPTION
## Fixes/Addresses:

- MacOS intel test are being skipped because the runner has been deprecated.  This updates the running so those tests should now run with macos-15-intel
- The linux runner was running out of disk space, so that was updated to ubuntu-24
- Add conda-forge or conda-remove-defaults to work with miniforge without warning

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
