### PR TITLE
Switching all GHAs from miniconda to miniforge

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -100,9 +100,7 @@ jobs:
         with:
           activate-environment: ${{ env.FOQUS_CONDA_ENV_NAME_DEV }}
           python-version: ${{ matrix.python-version }}
-          miniconda-version: latest
-          channels: conda-forge
-          conda-remove-defaults: true
+          miniforge-version: latest
       - name: Set up FOQUS
         uses: ./.github/actions/setup-foqus
         with:
@@ -179,6 +177,7 @@ jobs:
         with:
           activate-environment: ${{ env.FOQUS_CONDA_ENV_NAME_DEV }}
           python-version: ${{ matrix.python-version }}
+          miniforge-version: latest
       - name: Set up FOQUS
         uses: ./.github/actions/setup-foqus
         with:
@@ -197,6 +196,7 @@ jobs:
         with:
           activate-environment: ${{ env.FOQUS_CONDA_ENV_NAME_DEV }}
           python-version: ${{ matrix.python-version }}
+          miniforge-version: latest
       - name: Set up FOQUS
         uses: ./.github/actions/setup-foqus
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -101,6 +101,8 @@ jobs:
           activate-environment: ${{ env.FOQUS_CONDA_ENV_NAME_DEV }}
           python-version: ${{ matrix.python-version }}
           miniforge-version: latest
+          channels: conda-forge
+          conda-remove-defaults: true
       - name: Set up FOQUS
         uses: ./.github/actions/setup-foqus
         with:
@@ -178,6 +180,8 @@ jobs:
           activate-environment: ${{ env.FOQUS_CONDA_ENV_NAME_DEV }}
           python-version: ${{ matrix.python-version }}
           miniforge-version: latest
+          channels: conda-forge
+          conda-remove-defaults: true
       - name: Set up FOQUS
         uses: ./.github/actions/setup-foqus
         with:
@@ -197,6 +201,8 @@ jobs:
           activate-environment: ${{ env.FOQUS_CONDA_ENV_NAME_DEV }}
           python-version: ${{ matrix.python-version }}
           miniforge-version: latest
+          channels: conda-forge
+          conda-remove-defaults: true
       - name: Set up FOQUS
         uses: ./.github/actions/setup-foqus
         with:

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -53,9 +53,7 @@ jobs:
       - name: Set up Conda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-version: "latest"
-          channels: conda-forge
-          conda-remove-defaults: true
+          miniforge-version: latest
       - name: Install FOQUS in a Conda env (user mode)
         env:
           py_ver: ${{ matrix.python-version }}

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -54,6 +54,8 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
+          channels: conda-forge
+          conda-remove-defaults: true
       - name: Install FOQUS in a Conda env (user mode)
         env:
           py_ver: ${{ matrix.python-version }}


### PR DESCRIPTION
## Fixes/Addresses:

There were still a few warnings about adding the default channel implicitly in GHA.  I think this switch to explicitly using `miniforge-version: latest` will eliminate the need to be explicit on which is the default channel, as the default for miniforge should already be conda-forge.

## Summary/Motivation:


## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
