### PR TITLE
remove python 3.9 in tests and docs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -65,7 +65,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'
@@ -168,7 +167,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.9'
+          - '3.10'
           - '3.12'
         os:
           - linux
@@ -47,7 +47,7 @@ jobs:
             pip-install-target: https://github.com/CCSI-Toolset/FOQUS/archive/master.zip
           - foqus-install-target: stable
             os: win64
-            python-version: '3.9'
+            python-version: '3.10'
 
     steps: 
       - name: Set up Conda

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # the build.os and build.tools section is mandatory
 build:
-  os: ubuntu-22.04  # for consistency, matches the one used for CI
+  os: ubuntu-24.04  # for consistency, matches the one used for CI
   tools:
-    python: "3.9"
+    python: "3.10"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/source/chapt_install/install_python.rst
+++ b/docs/source/chapt_install/install_python.rst
@@ -3,7 +3,7 @@
 Install Python
 --------------
 
-Python version 3.9 up through 3.12 is required to run FOQUS.
+Python version 3.10 up through 3.12 is required to run FOQUS.
 
 We recommend using either the `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ or
 `Anaconda <https://www.anaconda.com/download/>`_ Python distribution and package management
@@ -17,7 +17,7 @@ ability to create self-contained python environments without any need for admini
 privileges. These separate environments can have different set of packages, isolating version
 dependencies when working with multiple python projects.
 
-If you have a working version of Python 3.9 through 3.12, which you prefer over Anaconda, you can
+If you have a working version of Python 3.10 through 3.12, which you prefer over Anaconda, you can
 skip these steps.
 
 Anaconda or Miniconda Install and Setup


### PR DESCRIPTION
## Fixes/Addresses:

Python 3.9 has been EOL'd.  This removes python 3.9 from tests and docs.

## Summary/Motivation:

This is needed for the black upgrade (PR #1283).

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the copyright and license terms described in the LICENSE.md file at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
